### PR TITLE
simulate selecting an option!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## master
+
+New features:
+
+  - added `selectOption`
+
+
 ## 2.1.0
 
 New features:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "elm": "^0.19.0-bugfix2",
     "elm-format": "^0.8.1",
-    "elm-test": "^0.19.0-rev3"
+    "elm-test": "^0.19.0-rev6"
   },
   "scripts": {
     "test": "elm-test && elm make --docs documentation.json && elm-format --validate . && elm diff"

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -833,7 +833,35 @@ check fieldId label willBecomeChecked testContext =
         testContext
 
 
-{-| great docs
+{-| Simulates choosing an option with the given text in a select with a given label
+
+Example: If you have a view like the following,
+
+    import Html
+    import Html.Attributes exposing (for, id, value)
+    import Html.Events exposing (on)
+
+    Html.div []
+        [ Html.label [ for "pet-select" ] [ Html.text "Choose a pet" ]
+        , Html.select [ id "on "change" targetValue ]
+             [ Html.option [ value "dog" ] [ Html.text "Dog" ]
+             , Html.option [ value "hamster" ] [ Html.text "Hamster" ]
+             ]
+        ]
+
+you can simulate selecting an option like this:
+
+    TestContext.selectOption "pet-select" "Choose a pet" "dog" "Dog"
+
+NOTE: Currently, this function requires that you also provide the field id
+(which must match both the `id` attribute of the target `select` element,
+and the `for` attribute of the `label` element) and the value of the option that you are
+selecting. After [eeue56/elm-html-test#51](https://github.com/eeue56/elm-html-test/issues/51) is resolved,
+a future release of this package will remove the `fieldId` and `optionValue` parameters.
+
+If you need more control over the finding the target element or creating the simulated event,
+see [`simulate`](#simulate).
+
 -}
 selectOption : String -> String -> String -> String -> TestContext msg model effect -> TestContext msg model effect
 selectOption fieldId label optionValue optionText testContext =

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -6,7 +6,7 @@ module TestContext exposing
     , createWithSimulatedEffects
     , clickButton, clickLink
     , fillIn, fillInTextarea
-    , check
+    , check, selectOption
     , routeChange
     , simulate
     , within
@@ -42,7 +42,7 @@ module TestContext exposing
 
 @docs clickButton, clickLink
 @docs fillIn, fillInTextarea
-@docs check
+@docs check, selectOption
 @docs routeChange
 
 
@@ -831,6 +831,58 @@ check fieldId label willBecomeChecked testContext =
         [ Selector.attribute (Html.Attributes.type_ "checkbox") ]
         (Test.Html.Event.check willBecomeChecked)
         testContext
+
+
+{-| great docs
+-}
+selectOption : String -> String -> String -> String -> TestContext msg model effect -> TestContext msg model effect
+selectOption fieldId label optionValue optionText testContext =
+    let
+        functionDescription =
+            String.join " "
+                [ "selectOption"
+                , escapeString fieldId
+                , escapeString label
+                , escapeString optionValue
+                , escapeString optionText
+                ]
+    in
+    testContext
+        |> expectViewHelper functionDescription
+            (Query.find
+                [ Selector.tag "label"
+                , Selector.attribute (Html.Attributes.for fieldId)
+                , Selector.text label
+                ]
+                >> Query.has []
+            )
+        |> expectViewHelper functionDescription
+            (Query.find
+                [ Selector.tag "select"
+                , Selector.id fieldId
+                , Selector.containing
+                    [ Selector.tag "option"
+                    , Selector.attribute (Html.Attributes.value optionValue)
+                    , Selector.text optionText
+                    ]
+                ]
+                >> Query.has []
+            )
+        |> simulateHelper functionDescription
+            (Query.find
+                [ Selector.tag "select"
+                , Selector.id fieldId
+                ]
+            )
+            ( "change"
+            , Json.Encode.object
+                [ ( "target"
+                  , Json.Encode.object
+                        [ ( "value", Json.Encode.string optionValue )
+                        ]
+                  )
+                ]
+            )
 
 
 {-| Focus on a part of the view for a particular operation.

--- a/tests/TestContextUserInputTests.elm
+++ b/tests/TestContextUserInputTests.elm
@@ -1,0 +1,63 @@
+module TestContextUserInputTests exposing (all)
+
+import Expect
+import Html exposing (Html)
+import Html.Attributes exposing (for, id, value)
+import Html.Events exposing (on)
+import Json.Decode
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+import Test.Runner
+import TestContext exposing (TestContext)
+
+
+testContext : TestContext String String ()
+testContext =
+    TestContext.create
+        { init = testInit
+        , update = testUpdate
+        , view = testView
+        }
+
+
+testInit : ( String, () )
+testInit =
+    ( "<INIT>"
+    , ()
+    )
+
+
+testUpdate : String -> String -> ( String, () )
+testUpdate msg model =
+    ( model ++ ";" ++ msg
+    , ()
+    )
+
+
+testView : String -> Html String
+testView model =
+    Html.div []
+        [ Html.label [ for "pet-select" ] [ Html.text "Choose a pet" ]
+        , Html.select
+            [ id "pet-select"
+            , on "change" Html.Events.targetValue
+            ]
+            [ Html.option [ value "dog-value" ] [ Html.text "Dog" ]
+            , Html.option [ value "cat-value" ] [ Html.text "Cat" ]
+            , Html.option [ value "hamster-value" ] [ Html.text "Hamster" ]
+            ]
+        ]
+
+
+all : Test
+all =
+    describe "simulating user input"
+        [ describe "selectOption"
+            [ test "can select an option" <|
+                \() ->
+                    testContext
+                        |> TestContext.selectOption "pet-select" "Choose a pet" "hamster-value" "Hamster"
+                        |> TestContext.expectModel (Expect.equal "<INIT>;hamster-value")
+            ]
+        ]

--- a/tests/TestContextUserInputTests.elm
+++ b/tests/TestContextUserInputTests.elm
@@ -1,6 +1,6 @@
 module TestContextUserInputTests exposing (all)
 
-import Expect
+import Expect exposing (Expectation)
 import Html exposing (Html)
 import Html.Attributes exposing (for, id, value)
 import Html.Events exposing (on)
@@ -46,6 +46,14 @@ testView model =
             [ Html.option [ value "dog-value" ] [ Html.text "Dog" ]
             , Html.option [ value "cat-value" ] [ Html.text "Cat" ]
             , Html.option [ value "hamster-value" ] [ Html.text "Hamster" ]
+            , Html.option [] [ Html.text "Tegu" ]
+            ]
+        , Html.label [ for "name-select" ] [ Html.text "Choose a name" ]
+        , Html.select
+            [ id "name-select"
+            ]
+            [ Html.option [ value "hamster-value" ] [ Html.text "Hamster" ]
+            , Html.option [ value "george-value" ] [ Html.text "George" ]
             ]
         ]
 
@@ -59,5 +67,31 @@ all =
                     testContext
                         |> TestContext.selectOption "pet-select" "Choose a pet" "hamster-value" "Hamster"
                         |> TestContext.expectModel (Expect.equal "<INIT>;hamster-value")
+            , test "fails if there is no onChange handler" <|
+                \() ->
+                    testContext
+                        |> TestContext.selectOption "name-select" "Choose a name" "george-value" "George"
+                        |> TestContext.done
+                        |> Test.Runner.getFailureReason
+                        |> Maybe.map .description
+                        |> Maybe.withDefault "<Expected selectOption to fail, but it succeeded>"
+                        |> Expect.all
+                            [ expectContains "selectOption"
+                            , expectContains "The event change does not exist on the found node."
+                            ]
             ]
         ]
+
+
+expectContains : String -> String -> Expectation
+expectContains expectedString actualString =
+    if String.contains expectedString actualString then
+        Expect.pass
+
+    else
+        Expect.fail
+            ("Expected string containing: "
+                ++ expectedString
+                ++ "\nBut got: "
+                ++ actualString
+            )


### PR DESCRIPTION
This adds the `selectOption` function to simulate selecting an option.
 --- 

To test:

```html
...
   <label for="myselect">The thing to select</label>
   <select id="myselect">
       <option value="1">Mine</option>
       <option value="2" selected>Belongs to me</option>
    </select>
```

```elm
selectOption : String -> String -> String -> TestContext -> TestContext
selectOption id label optionLabel
```

- [x] choose an option by name from a select
- [x] choose an option from a select when there's another selection with an option of the same name on the page
- [x] fails if there's no onChange handler
- [ ] fails if there's no matching option
- [ ] fails if there's no matching select
     - or if the label.for doesn't match the select.id
- [ ] should work if there's no explicit value attribute on the option
- [ ] ?? what if there are multiple options in the select with the same name?


other:
- [ ] fail when "disabled" is set (for all input types, not just select)