### PR TITLE
Rename TestContext -> ProgramTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for testing your Elm programs as complete units.
 
 ## Basic example
 
-In this example, `TestContext.create` is used to initiate testing of the imagined `MyProgram` module
+In this example, `ProgramTest.create` is used to initiate testing of the imagined `MyProgram` module
 (which follows the [Elm architecture](https://guide.elm-lang.org/architecture/)).
 Then `clickButton` is used to simulate user interaction with the program,
 and finally `expectViewHas` is used to assert the final state of the program's displayed HTML.
@@ -19,14 +19,14 @@ and finally `expectViewHas` is used to assert the final state of the program's d
 ```elm
 import Test exposing (..)
 import Test.Html.Selector exposing (class, text)
-import TestContext exposing (clickButton, expectViewHas, start)
+import ProgramTest exposing (clickButton, expectViewHas, start)
 import MyProgram -- just an imaginary example
 
 exampleProgramTest : Test
 exampleProgramTest =
     test "cannot publish without a title" <|
         \() ->
-            TestContext.createElement
+            ProgramTest.createElement
                 { init = MyProgram.init
                 , update = MyProgram.update
                 , view = MyProgram.view
@@ -44,25 +44,25 @@ exampleProgramTest =
 ## Testing programs with flags and/or navigation
 
 This example tests a program that requires both [flags](https://guide.elm-lang.org/interop/javascript.html#flags) and [navigation](http://package.elm-lang.org/packages/elm-lang/navigation/latest).
-There are variants of the `TestContext.create*` functions ([see all](TestContext#creating)) for all combinations of
+There are variants of the `ProgramTest.create*` functions ([see all](ProgramTest#creating)) for all combinations of
 flags and/or navigation that a program might required.
 
 ```elm
 import Test exposing (..)
 import Test.Html.Selector exposing (class, text)
-import TestContext exposing (clickButton, expectViewHas)
+import ProgramTest exposing (ProgramTest clickButton, expectViewHas)
 import MyProgram exposing (Flags, Msg, Model) -- just an imaginary example
 
-start : String -> Flags ->  TestContext Msg Model (Cmd Msg)
+start : String -> Flags ->  ProgramTest Msg Model (Cmd Msg)
 start initialUrl flags =
-    TestContext.createApplication
+    ProgramTest.createApplication
         { onUrlChange = MyProgram.OnRouteChange
         , init = MyProgram.init -- the type of MyProgram.init is: MyProgram.Flags -> Navigation.Location -> (MyProgram.Model, Cmd MyProgram.Msg)
         , update = MyProgram.update
         , view = MyProgram.view
         }
-        |> TestContext.withBaseUrl initialUrl
-        |> TestContext.start flags
+        |> ProgramTest.withBaseUrl initialUrl
+        |> ProgramTest.start flags
 
 exampleProgramTest : Test
 exampleProgramTest =
@@ -87,22 +87,22 @@ This example tests a module for a complicated view by making a program with a tr
 import DateTimePicker -- using abadi199/datetimepicker 6.0.0 as an example of a view to test
 import Test exposing (..)
 import Test.Html.Selector exposing (text)
-import TestContext exposing (clickButton, expectViewHas)
+import ProgramTest exposing (clickButton, expectViewHas)
 
 startDatePicker :
-    TestContext
+    ProgramTest
         (DateTimePicker.State, Maybe Date) -- msg: in this trivial program, the msg is simply the new model value
         (DateTimePicker.State, Maybe Date) -- model: simply the state needed by the view being tested
         (Cmd never) -- effect: could use any type here, but Cmd seems least confusing
 startDatePicker =
-    TestContext.element
+    ProgramTest.element
         { init = \() -> ((DateTimePicker.initialState, Nothing), Cmd.none)
         , update = newState model -> (newState, Cmd.none)
         , view =
             \(state, value) ->
                 DateTimePicker.dateTimePicker (,) [] state value
         }
-        |> TestContext.start ()
+        |> ProgramTest.start ()
 
 datePickerTest : Test
 datePickerTest =

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -42,26 +42,26 @@ Here's what that test will look like in code:
 import Expect
 import Json.Decode
 import Json.Encode
+import ProgramTest
 import Test exposing (test)
-import TestContext
 
 test "checking grammar" <|
     \() ->
         start
-            |> TestContext.fillIn "main"
+            |> ProgramTest.fillIn "main"
                 "Enter text to check"
                 "The youngest man the boat."
-            |> TestContext.clickButton "Check"
-            |> TestContext.assertAndClearOutgoingPortValues
+            |> ProgramTest.clickButton "Check"
+            |> ProgramTest.assertAndClearOutgoingPortValues
                 "checkGrammar"
                 Json.Decode.string
                 (Expect.equal [ "The youngest man the boat." ])
-            |> TestContext.simulateIncomingPort
+            |> ProgramTest.simulateIncomingPort
                 "grammarCheckResults"
                 (Json.Encode.list Json.Encode.string
                     [ "Garden-path sentences can confuse the reader." ]
                 )
-            |> TestContext.expectViewHas
+            |> ProgramTest.expectViewHas
                 [ text "Garden-path sentences can confuse the reader." ]
 ```
 
@@ -71,7 +71,7 @@ so that the test can simulate the incoming and outgoing ports.
 
 ## Simulating outgoing ports
 
-We'll assume that we already have our test set up with `TestContext.withSimulatedEffects`
+We'll assume that we already have our test set up with `ProgramTest.withSimulatedEffects`
 (if you're not familiar with that,
 you should first follow the ["testing programs that use Cmds" guide](cmds.md)).
 
@@ -82,7 +82,7 @@ in our `simulateEffects` function:
 import Json.Encode
 import SimulatedEffect.Ports
 
-simulateEffects : Main.Effect -> TestContext.SimulatedEffect Main.Msg
+simulateEffects : Main.Effect -> ProgramTest.SimulatedEffect Main.Msg
 simulateEffects effect =
     case effect of
         ...
@@ -96,7 +96,7 @@ simulateEffects effect =
 Similar to how we provided a `simulateEffects` function for testing our Cmds,
 we'll need to provide a `simulateSubscriptions` function for testing our Subs.
 This will parallel the `subscriptions` function in our main program,
-but will return `TestContext.SimulatedSub` instead of the normal `Sub`.
+but will return `ProgramTest.SimulatedSub` instead of the normal `Sub`.
 (This is necessary because, as with `Cmd`s,
 Elm currently provides no way to inspect the value of a `Sub`.)
 
@@ -113,26 +113,26 @@ subscriptions _ =
 And here's the corresponding `simulateSubscriptions` function we'll write for our test setup:
 
 ```elm
-simulateSubscriptions : Main.Model -> TestContext.SimulatedSub Main.Msg
+simulateSubscriptions : Main.Model -> ProgramTest.SimulatedSub Main.Msg
 simulateSubscriptions _ =
     SimulatedEffect.Ports.subscribe "grammarCheckResults"
         (Json.Decode.list Json.Decode.string)
         Main.GrammarCheckResults
 ```
 
-Finally, we configure our `TestContext` with the `simulateSubscriptions` function before starting it:
+Finally, we configure our `ProgramTest` with the `simulateSubscriptions` function before starting it:
 
 ```elm{9}
-start : TestContext Main.Msg Main.Model Main.Effect
+start : ProgramTest Main.Msg Main.Model Main.Effect
 start =
-    TestContext.createDocument
+    ProgramTest.createDocument
         { init = Main.init
         , update = Main.update
         , view = Main.view
         }
-        |> TestContext.withSimulatedEffects simulateEffects
-        |> TestContext.withSimulatedSubscriptions simulateSub
-        |> TestContext.start ()
+        |> ProgramTest.withSimulatedEffects simulateEffects
+        |> ProgramTest.withSimulatedSubscriptions simulateSub
+        |> ProgramTest.start ()
 ```
 
 

--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "version": "2.3.2",
     "exposed-modules": [
-        "TestContext",
+        "ProgramTest",
         "SimulatedEffect.Cmd",
         "SimulatedEffect.Sub",
         "SimulatedEffect.Http",

--- a/examples/tests/GrammarCheckingExampleTest.elm
+++ b/examples/tests/GrammarCheckingExampleTest.elm
@@ -4,23 +4,23 @@ import Expect
 import GrammarCheckingExample as Main
 import Json.Decode
 import Json.Encode
+import ProgramTest exposing (ProgramTest)
 import SimulatedEffect.Cmd
 import SimulatedEffect.Ports
 import Test exposing (..)
 import Test.Html.Selector exposing (text)
-import TestContext exposing (TestContext)
 
 
-start : TestContext Main.Msg Main.Model Main.Effect
+start : ProgramTest Main.Msg Main.Model Main.Effect
 start =
-    TestContext.createDocument
+    ProgramTest.createDocument
         { init = Main.init
         , update = Main.update
         , view = Main.view
         }
-        |> TestContext.withSimulatedEffects simulateEffects
-        |> TestContext.withSimulatedSubscriptions simulateSub
-        |> TestContext.start ()
+        |> ProgramTest.withSimulatedEffects simulateEffects
+        |> ProgramTest.withSimulatedSubscriptions simulateSub
+        |> ProgramTest.start ()
 
 
 all : Test
@@ -29,25 +29,25 @@ all =
         [ test "checking grammar" <|
             \() ->
                 start
-                    |> TestContext.fillIn "main"
+                    |> ProgramTest.fillIn "main"
                         "Enter text to check"
                         "The youngest man the boat."
-                    |> TestContext.clickButton "Check"
-                    |> TestContext.assertAndClearOutgoingPortValues
+                    |> ProgramTest.clickButton "Check"
+                    |> ProgramTest.assertAndClearOutgoingPortValues
                         "checkGrammar"
                         Json.Decode.string
                         (Expect.equal [ "The youngest man the boat." ])
-                    |> TestContext.simulateIncomingPort
+                    |> ProgramTest.simulateIncomingPort
                         "grammarCheckResults"
                         (Json.Encode.list Json.Encode.string
                             [ "Garden-path sentences can confuse the reader." ]
                         )
-                    |> TestContext.expectViewHas
+                    |> ProgramTest.expectViewHas
                         [ text "Garden-path sentences can confuse the reader." ]
         ]
 
 
-simulateEffects : Main.Effect -> TestContext.SimulatedEffect Main.Msg
+simulateEffects : Main.Effect -> ProgramTest.SimulatedEffect Main.Msg
 simulateEffects effect =
     case effect of
         Main.NoEffect ->
@@ -57,7 +57,7 @@ simulateEffects effect =
             SimulatedEffect.Ports.send "checkGrammar" (Json.Encode.string text)
 
 
-simulateSub : Main.Model -> TestContext.SimulatedSub Main.Msg
+simulateSub : Main.Model -> ProgramTest.SimulatedSub Main.Msg
 simulateSub _ =
     SimulatedEffect.Ports.subscribe "grammarCheckResults"
         (Json.Decode.list Json.Decode.string)

--- a/examples/tests/HomeAutomationExampleTest.elm
+++ b/examples/tests/HomeAutomationExampleTest.elm
@@ -2,21 +2,21 @@ module HomeAutomationExampleTest exposing (all)
 
 import Expect
 import HomeAutomationExample as Main
+import ProgramTest exposing (ProgramTest)
 import SimulatedEffect.Cmd
 import SimulatedEffect.Http
 import Test exposing (..)
-import TestContext exposing (TestContext)
 
 
-start : TestContext Main.Msg Main.Model Main.Effect
+start : ProgramTest Main.Msg Main.Model Main.Effect
 start =
-    TestContext.createDocument
+    ProgramTest.createDocument
         { init = Main.init
         , update = Main.update
         , view = Main.view
         }
-        |> TestContext.withSimulatedEffects simulateEffects
-        |> TestContext.start ()
+        |> ProgramTest.withSimulatedEffects simulateEffects
+        |> ProgramTest.start ()
 
 
 all : Test
@@ -25,20 +25,20 @@ all =
         [ test "controlling a light" <|
             \() ->
                 start
-                    |> TestContext.simulateHttpOk
+                    |> ProgramTest.simulateHttpOk
                         "GET"
                         "http://localhost:8003/lighting_service/v1/devices"
                         """[{"id":"K001", "name":"Kitchen", "dimmable":false, "value":0}]"""
-                    |> TestContext.clickButton "Turn on"
-                    |> TestContext.assertHttpRequest
+                    |> ProgramTest.clickButton "Turn on"
+                    |> ProgramTest.assertHttpRequest
                         "POST"
                         "http://localhost:8003/lighting_service/v1/devices/K001"
                         (.body >> Expect.equal """{"value":1}""")
-                    |> TestContext.done
+                    |> ProgramTest.done
         ]
 
 
-simulateEffects : Main.Effect -> TestContext.SimulatedEffect Main.Msg
+simulateEffects : Main.Effect -> ProgramTest.SimulatedEffect Main.Msg
 simulateEffects effect =
     case effect of
         Main.NoEffect ->

--- a/src/ProgramTest/EffectSimulation.elm
+++ b/src/ProgramTest/EffectSimulation.elm
@@ -1,4 +1,4 @@
-module TestContext.EffectSimulation exposing
+module ProgramTest.EffectSimulation exposing
     ( EffectSimulation
     , SimulationState
     , clearOutgoingPortValues

--- a/src/SimulatedEffect/Cmd.elm
+++ b/src/SimulatedEffect/Cmd.elm
@@ -6,7 +6,7 @@ module SimulatedEffect.Cmd exposing
 {-| This module parallels [elm/core's `Platform.Cmd` module](https://package.elm-lang.org/packages/elm/core/1.0.2/Platform-Cmd).
 
 The functions here produce `SimulatedEffect`s instead of `Cmd`s, which are meant to be used
-to help you implement the function to provide when using [`TestContext.withSimulatedEffects`](TestContext#withSimulatedEffects).
+to help you implement the function to provide when using [`ProgramTest.withSimulatedEffects`](ProgramTest#withSimulatedEffects).
 
 @docs none, batch
 

--- a/src/SimulatedEffect/Http.elm
+++ b/src/SimulatedEffect/Http.elm
@@ -11,7 +11,7 @@ module SimulatedEffect.Http exposing
 PRs are welcome to add any functions that are missing.
 
 The functions here produce `SimulatedEffect`s instead of `Cmd`s, which are meant to be used
-to help you implement the function to provide when using [`TestContext.withSimulatedEffects`](TestContext#withSimulatedEffects).
+to help you implement the function to provide when using [`ProgramTest.withSimulatedEffects`](ProgramTest#withSimulatedEffects).
 
 
 # Requests

--- a/src/SimulatedEffect/Navigation.elm
+++ b/src/SimulatedEffect/Navigation.elm
@@ -4,7 +4,7 @@ module SimulatedEffect.Navigation exposing (pushUrl, replaceUrl)
 PRs are welcome to add any functions that are missing.
 
 The functions here produce `SimulatedEffect`s instead of `Cmd`s, which are meant to be used
-to help you implement the function to provide when using [`TestContext.withSimulatedEffects`](TestContext#withSimulatedEffects).
+to help you implement the function to provide when using [`ProgramTest.withSimulatedEffects`](ProgramTest#withSimulatedEffects).
 
 
 # Navigate within Page

--- a/src/SimulatedEffect/Ports.elm
+++ b/src/SimulatedEffect/Ports.elm
@@ -4,8 +4,8 @@ module SimulatedEffect.Ports exposing (send, subscribe)
 that parallel [Elm ports](https://guide.elm-lang.org/interop/ports.html) used in your real program.
 This is meant to be used
 to help you implement the function to provide when using
-[`TestContext.withSimulatedEffects`](TestContext#withSimulatedEffects)
-and [`TestContext.withSimulatedSubscriptions`](TestContext#withSimulatedSubscriptions).
+[`ProgramTest.withSimulatedEffects`](ProgramTest#withSimulatedEffects)
+and [`ProgramTest.withSimulatedSubscriptions`](ProgramTest#withSimulatedSubscriptions).
 
 @docs send, subscribe
 

--- a/src/SimulatedEffect/Process.elm
+++ b/src/SimulatedEffect/Process.elm
@@ -4,7 +4,7 @@ module SimulatedEffect.Process exposing (sleep)
 PRs are welcome to add any functions that are missing.
 
 The functions here produce `SimulatedEffect`s instead of `Cmd`s, which are meant to be used
-to help you implement the function to provide when using [`TestContext.withSimulatedEffects`](TestContext#withSimulatedEffects).
+to help you implement the function to provide when using [`ProgramTest.withSimulatedEffects`](ProgramTest#withSimulatedEffects).
 
 
 # Processes

--- a/src/SimulatedEffect/Sub.elm
+++ b/src/SimulatedEffect/Sub.elm
@@ -6,7 +6,7 @@ module SimulatedEffect.Sub exposing
 {-| This module parallels [elm/core's `Platform.Sub` module](https://package.elm-lang.org/packages/elm/core/1.0.2/Platform-Sub).
 
 The functions here produce `SimulatedSub`s instead of `Sub`s, which are meant to be used
-to help you implement the function to provide when using [`TestContext.withSimulatedSubscriptions`](TestContext#withSimulatedSubscriptions).
+to help you implement the function to provide when using [`ProgramTest.withSimulatedSubscriptions`](ProgramTest#withSimulatedSubscriptions).
 
 @docs none, batch
 

--- a/src/SimulatedEffect/Task.elm
+++ b/src/SimulatedEffect/Task.elm
@@ -10,7 +10,7 @@ PRs are welcome to add any functions that are missing.
 
 The functions here produce `SimulatedTasks`s instead of `Tasks`s
 and `SimulatedEffect`s instead of `Cmd`s, which are meant to be used
-to help you implement the function to provide when using [`TestContext.withSimulatedEffects`](TestContext#withSimulatedEffects).
+to help you implement the function to provide when using [`ProgramTest.withSimulatedEffects`](ProgramTest#withSimulatedEffects).
 
 
 # Tasks

--- a/src/Test/Http.elm
+++ b/src/Test/Http.elm
@@ -13,7 +13,7 @@ module Test.Http exposing
 
 ## Responses
 
-These are ways to easily make `Http.Response` values for use with [`TestContext.simulateHttpResponse`](TestContext#simulateHttpResponse).
+These are ways to easily make `Http.Response` values for use with [`ProgramTest.simulateHttpResponse`](ProgramTest#simulateHttpResponse).
 
 @docs timeout, networkError, httpResponse
 
@@ -29,7 +29,7 @@ import SimulatedEffect
 {-| A convenient way to check something about the request body of a pending HTTP request.
 
     ...
-        |> TestContext.assertHttpRequest "POST"
+        |> ProgramTest.assertHttpRequest "POST"
             "https://example.com/ok"
             (Test.Http.expectJsonBody
                 (Json.Decode.field "version" Json.Decode.string)
@@ -55,7 +55,7 @@ expectJsonBody decoder check request =
 {-| Assert that the given HTTP request has the specified header.
 
     ...
-        |> TestContext.assertHttpRequest "POST"
+        |> ProgramTest.assertHttpRequest "POST"
             "https://example.com/ok"
             (Test.Http.hasHeader "Content-Type" "application/json")
         |> ...

--- a/tests/ProgramTestTests.elm
+++ b/tests/ProgramTestTests.elm
@@ -1,4 +1,4 @@
-module TestContextTests exposing (all)
+module ProgramTestTests exposing (all)
 
 import Expect
 import Html exposing (Html)
@@ -6,11 +6,11 @@ import Html.Attributes exposing (for, id, type_)
 import Html.Events exposing (onClick)
 import Json.Decode
 import Json.Encode
+import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 import Test.Runner
-import TestContext exposing (TestContext)
 
 
 type TestEffect
@@ -78,52 +78,52 @@ testView model =
         ]
 
 
-testContext : TestContext String String TestEffect
-testContext =
-    TestContext.createElement
+start : ProgramTest String String TestEffect
+start =
+    ProgramTest.createElement
         { init = \() -> testInit
         , update = testUpdate
         , view = testView
         }
-        |> TestContext.start ()
+        |> ProgramTest.start ()
 
 
 all : Test
 all =
-    describe "TestContext"
+    describe "ProgramTest"
         [ test "has initial model" <|
             \() ->
-                testContext
-                    |> TestContext.expectModel (Expect.equal "<INIT>")
+                start
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>")
         , test "can send a msg" <|
             \() ->
-                testContext
-                    |> TestContext.update "A"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;A")
+                start
+                    |> ProgramTest.update "A"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;A")
         , test "can create with flags" <|
             \() ->
-                TestContext.createElement
+                ProgramTest.createElement
                     { init = \flags -> ( "<INIT:" ++ flags ++ ">", NoOp )
                     , update = testUpdate
                     , view = testView
                     }
-                    |> TestContext.start "flags"
-                    |> TestContext.expectModel (Expect.equal "<INIT:flags>")
+                    |> ProgramTest.start "flags"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT:flags>")
         , test "can create with JSON string flags" <|
             \() ->
-                TestContext.createElement
+                ProgramTest.createElement
                     { init = \flags -> ( "<INIT:" ++ flags ++ ">", NoOp )
                     , update = testUpdate
                     , view = testView
                     }
-                    |> TestContext.withJsonStringFlags (Json.Decode.field "y" Json.Decode.string)
-                    |> TestContext.start """{"y": "fromJson"}"""
-                    |> TestContext.expectModel (Expect.equal "<INIT:fromJson>")
+                    |> ProgramTest.withJsonStringFlags (Json.Decode.field "y" Json.Decode.string)
+                    |> ProgramTest.start """{"y": "fromJson"}"""
+                    |> ProgramTest.expectModel (Expect.equal "<INIT:fromJson>")
         , test "can create with navigation" <|
             \() ->
-                TestContext.createApplication
+                ProgramTest.createApplication
                     { onUrlChange = .path
-                    , onUrlRequest = \_ -> Debug.todo "TestContextTests-1:onUrlRequest"
+                    , onUrlRequest = \_ -> Debug.todo "ProgramTestTests-1:onUrlRequest"
                     , init = \() location key -> ( "<INIT:" ++ location.path ++ ">", NoOp )
                     , update = testUpdate
                     , view =
@@ -132,14 +132,14 @@ all =
                             , body = [ testView model ]
                             }
                     }
-                    |> TestContext.withBaseUrl "https://example.com/path"
-                    |> TestContext.start ()
-                    |> TestContext.expectModel (Expect.equal "<INIT:/path>")
+                    |> ProgramTest.withBaseUrl "https://example.com/path"
+                    |> ProgramTest.start ()
+                    |> ProgramTest.expectModel (Expect.equal "<INIT:/path>")
         , test "can create with navigation and flags" <|
             \() ->
-                TestContext.createApplication
+                ProgramTest.createApplication
                     { onUrlChange = .path
-                    , onUrlRequest = \_ -> Debug.todo "TestContextTests-4:onUrlRequest"
+                    , onUrlRequest = \_ -> Debug.todo "ProgramTestTests-4:onUrlRequest"
                     , init = \flags location key -> ( "<INIT:" ++ location.path ++ ":" ++ flags ++ ">", NoOp )
                     , update = testUpdate
                     , view =
@@ -148,25 +148,25 @@ all =
                             , body = [ testView model ]
                             }
                     }
-                    |> TestContext.withBaseUrl "https://example.com/path"
-                    |> TestContext.start "flags"
-                    |> TestContext.expectModel (Expect.equal "<INIT:/path:flags>")
+                    |> ProgramTest.withBaseUrl "https://example.com/path"
+                    |> ProgramTest.start "flags"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT:/path:flags>")
         , test "can assert on the view" <|
             \() ->
-                testContext
-                    |> TestContext.shouldHaveView
+                start
+                    |> ProgramTest.shouldHaveView
                         (Query.find [ Selector.tag "span" ] >> Query.has [ Selector.text "<INIT>" ])
-                    |> TestContext.done
+                    |> ProgramTest.done
         , test "can assert on the view concisely with a terminal assertion" <|
             \() ->
-                testContext
-                    |> TestContext.expectView
+                start
+                    |> ProgramTest.expectView
                         (Query.find [ Selector.tag "span" ] >> Query.has [ Selector.text "<INIT>" ])
         , test "can create with navigation and JSON string flags" <|
             \() ->
-                TestContext.createApplication
+                ProgramTest.createApplication
                     { onUrlChange = .path
-                    , onUrlRequest = \_ -> Debug.todo "TestContextTests-5:onUrlRequest"
+                    , onUrlRequest = \_ -> Debug.todo "ProgramTestTests-5:onUrlRequest"
                     , init = \flags location key -> ( "<INIT:" ++ location.path ++ ":" ++ flags ++ ">", NoOp )
                     , update = testUpdate
                     , view =
@@ -175,81 +175,81 @@ all =
                             , body = [ testView model ]
                             }
                     }
-                    |> TestContext.withJsonStringFlags (Json.Decode.field "x" Json.Decode.string)
-                    |> TestContext.withBaseUrl "https://example.com/path"
-                    |> TestContext.start """{"x": "fromJson"}"""
-                    |> TestContext.expectModel (Expect.equal "<INIT:/path:fromJson>")
+                    |> ProgramTest.withJsonStringFlags (Json.Decode.field "x" Json.Decode.string)
+                    |> ProgramTest.withBaseUrl "https://example.com/path"
+                    |> ProgramTest.start """{"x": "fromJson"}"""
+                    |> ProgramTest.expectModel (Expect.equal "<INIT:/path:fromJson>")
         , test "can assert on the view concisely given Html.Test.Selectors" <|
             \() ->
-                testContext
-                    |> TestContext.shouldHave [ Selector.tag "span" ]
-                    |> TestContext.done
+                start
+                    |> ProgramTest.shouldHave [ Selector.tag "span" ]
+                    |> ProgramTest.done
         , test "can assert on the view concisely with a terminal assertion given Html.Test.Selectors" <|
             \() ->
-                testContext
-                    |> TestContext.expectViewHas [ Selector.tag "span" ]
+                start
+                    |> ProgramTest.expectViewHas [ Selector.tag "span" ]
         , test "can assert on the view concisely given Html.Test.Selectors that should not exist" <|
             \() ->
-                testContext
-                    |> TestContext.shouldNotHave [ Selector.tag "article" ]
-                    |> TestContext.done
+                start
+                    |> ProgramTest.shouldNotHave [ Selector.tag "article" ]
+                    |> ProgramTest.done
         , test "can simulate an arbitrary DOM event" <|
             \() ->
-                testContext
-                    |> TestContext.simulate
+                start
+                    |> ProgramTest.simulate
                         (Query.find [ Selector.tag "strange" ])
                         ( "odd", Json.Encode.string "<ODD-VALUE>" )
-                    |> TestContext.expectModel (Expect.equal "<INIT>;<ODD-VALUE>")
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;<ODD-VALUE>")
         , test "can assert on the last effect after init" <|
             \() ->
-                testContext
-                    |> TestContext.expectLastEffect (Expect.equal NoOp)
+                start
+                    |> ProgramTest.expectLastEffect (Expect.equal NoOp)
         , test "can assert on the last effect after update" <|
             \() ->
-                testContext
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.expectLastEffect (Expect.equal (LogUpdate "CLICK"))
+                start
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.expectLastEffect (Expect.equal (LogUpdate "CLICK"))
         , test "can assert on the last effect as an intermediate assertion" <|
             \() ->
-                testContext
-                    |> TestContext.shouldHaveLastEffect (Expect.equal NoOp)
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.shouldHaveLastEffect (Expect.equal (LogUpdate "CLICK"))
-                    |> TestContext.done
+                start
+                    |> ProgramTest.shouldHaveLastEffect (Expect.equal NoOp)
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.shouldHaveLastEffect (Expect.equal (LogUpdate "CLICK"))
+                    |> ProgramTest.done
         , test "can simulate a response to the last effect" <|
             \() ->
-                testContext
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.simulateLastEffect (\effect -> Ok [ Debug.toString effect ])
-                    |> TestContext.expectModel (Expect.equal "<INIT>;CLICK;LogUpdate \"CLICK\"")
+                start
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.simulateLastEffect (\effect -> Ok [ Debug.toString effect ])
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;CLICK;LogUpdate \"CLICK\"")
         , test "can force a failure via simulateLastEffect" <|
             \() ->
-                testContext
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.simulateLastEffect (\effect -> Err "Unexpected effect")
-                    |> TestContext.done
+                start
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.simulateLastEffect (\effect -> Err "Unexpected effect")
+                    |> ProgramTest.done
                     |> Test.Runner.getFailureReason
                     |> Maybe.map .description
                     |> Expect.equal (Just "simulateLastEffect failed: Unexpected effect")
         , test "can be forced into failure" <|
             \() ->
-                testContext
-                    |> TestContext.fail "custom" "Because I said so"
-                    |> TestContext.done
+                start
+                    |> ProgramTest.fail "custom" "Because I said so"
+                    |> ProgramTest.done
                     |> Test.Runner.getFailureReason
                     |> Maybe.map .description
                     |> Expect.equal (Just "custom: Because I said so")
         , test "can narrow down the area to specified element" <|
             \() ->
-                testContext
-                    |> TestContext.within
+                start
+                    |> ProgramTest.within
                         (Query.find [ Selector.id "button-b" ])
-                        (TestContext.clickButton "Ambiguous click")
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;CLICK-B;CLICK")
+                        (ProgramTest.clickButton "Ambiguous click")
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;CLICK-B;CLICK")
         , test "can simulate setting a labeled checkbox field" <|
             \() ->
-                testContext
-                    |> TestContext.check "checkbox-1" "Checkbox 1" True
-                    |> TestContext.expectModel (Expect.equal "<INIT>;Check:checkbox-1:True")
+                start
+                    |> ProgramTest.check "checkbox-1" "Checkbox 1" True
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Check:checkbox-1:True")
         ]

--- a/tests/ProgramTestTests/SimulatedEffects/BasicTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/BasicTest.elm
@@ -1,13 +1,13 @@
-module TestContextTests.SimulatedEffects.BasicTest exposing (all)
+module ProgramTestTests.SimulatedEffects.BasicTest exposing (all)
 
 import Expect
+import ProgramTest exposing (ProgramTest, SimulatedEffect, SimulatedTask)
 import SimulatedEffect.Task as Task
 import Test exposing (..)
-import TestContext exposing (SimulatedEffect, SimulatedTask, TestContext)
 import TestingProgram exposing (Msg(..))
 
 
-startTask : SimulatedTask x a -> TestingProgram.TestContext
+startTask : SimulatedTask x a -> TestingProgram.ProgramTest
 startTask initialTask =
     TestingProgram.startEffects
         (Task.attempt (Debug.toString >> Log) initialTask)
@@ -19,13 +19,13 @@ all =
         [ test "simulates Task.succeed" <|
             \() ->
                 startTask (Task.succeed ())
-                    |> TestContext.expectModel (Expect.equal [ "Ok ()" ])
+                    |> ProgramTest.expectModel (Expect.equal [ "Ok ()" ])
         , test "simulates Task.fail" <|
             \() ->
                 startTask (Task.fail ())
-                    |> TestContext.expectModel (Expect.equal [ "Err ()" ])
+                    |> ProgramTest.expectModel (Expect.equal [ "Err ()" ])
         , test "simulated Task.andThen" <|
             \() ->
                 startTask (Task.succeed 5 |> Task.andThen ((+) 10 >> Task.fail))
-                    |> TestContext.expectModel (Expect.equal [ "Err 15" ])
+                    |> ProgramTest.expectModel (Expect.equal [ "Err 15" ])
         ]

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -1,10 +1,10 @@
-module TestContextTests.SimulatedEffects.NavigationTest exposing (all)
+module ProgramTestTests.SimulatedEffects.NavigationTest exposing (all)
 
 import Expect
+import ProgramTest
 import SimulatedEffect.Cmd
 import SimulatedEffect.Navigation
 import Test exposing (..)
-import TestContext
 import TestingProgram exposing (Msg(..))
 
 
@@ -14,21 +14,21 @@ all =
         [ test "can simulate a route change" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Cmd.none
-                    |> TestContext.routeChange "https://example.com/new"
-                    |> TestContext.expectModel (Expect.equal [ "https://example.com/new" ])
+                    |> ProgramTest.routeChange "https://example.com/new"
+                    |> ProgramTest.expectModel (Expect.equal [ "https://example.com/new" ])
         , test "can simulate a route change with a relative URL" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Cmd.none
-                    |> TestContext.routeChange "/new"
-                    |> TestContext.expectModel (Expect.equal [ "https://example.com/new" ])
+                    |> ProgramTest.routeChange "/new"
+                    |> ProgramTest.expectModel (Expect.equal [ "https://example.com/new" ])
         , test "simulating a pushUrl triggers an onUrlChange" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Cmd.none
-                    |> TestContext.update (ProduceEffects (SimulatedEffect.Navigation.pushUrl "new"))
-                    |> TestContext.expectModel (Expect.equal [ "https://example.com/new" ])
+                    |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.pushUrl "new"))
+                    |> ProgramTest.expectModel (Expect.equal [ "https://example.com/new" ])
         , test "simulating a replaceUrl triggers an onUrlChange" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Cmd.none
-                    |> TestContext.update (ProduceEffects (SimulatedEffect.Navigation.replaceUrl "/new"))
-                    |> TestContext.expectModel (Expect.equal [ "https://example.com/new" ])
+                    |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.replaceUrl "/new"))
+                    |> ProgramTest.expectModel (Expect.equal [ "https://example.com/new" ])
         ]

--- a/tests/ProgramTestTests/SimulatedEffects/PortsTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/PortsTest.elm
@@ -1,15 +1,15 @@
-module TestContextTests.SimulatedEffects.PortsTest exposing (all)
+module ProgramTestTests.SimulatedEffects.PortsTest exposing (all)
 
 import Expect exposing (Expectation)
 import Html
 import Json.Decode as Decode
 import Json.Encode as Json
+import ProgramTest exposing (ProgramTest, SimulatedEffect, SimulatedTask)
 import SimulatedEffect.Cmd
 import SimulatedEffect.Ports
 import SimulatedEffect.Sub
 import Test exposing (..)
 import Test.Expect exposing (expectFailure)
-import TestContext exposing (SimulatedEffect, SimulatedTask, TestContext)
 import TestingProgram exposing (Msg(..))
 
 
@@ -24,13 +24,13 @@ all =
             [ test "can check sent values" <|
                 \() ->
                     start (SimulatedEffect.Ports.send "unit" Json.null)
-                        |> TestContext.assertAndClearOutgoingPortValues "unit" (Decode.null ()) (Expect.equal [ () ])
-                        |> TestContext.done
+                        |> ProgramTest.assertAndClearOutgoingPortValues "unit" (Decode.null ()) (Expect.equal [ () ])
+                        |> ProgramTest.done
             , test "gives error if checked values don't match" <|
                 \() ->
                     start (SimulatedEffect.Ports.send "unit" Json.null)
-                        |> TestContext.assertAndClearOutgoingPortValues "other" (Decode.null ()) (Expect.equal [ () ])
-                        |> TestContext.done
+                        |> ProgramTest.assertAndClearOutgoingPortValues "other" (Decode.null ()) (Expect.equal [ () ])
+                        |> ProgramTest.done
                         |> expectFailure
                             [ "assertAndClearOutgoingPortValues: values sent to port \"other\" did not match:"
                             , "[]"
@@ -42,20 +42,20 @@ all =
             , test "clears values after checking" <|
                 \() ->
                     start (SimulatedEffect.Ports.send "unit" Json.null)
-                        |> TestContext.assertAndClearOutgoingPortValues "unit" (Decode.null ()) (Expect.equal [ () ])
-                        |> TestContext.assertAndClearOutgoingPortValues "unit" (Decode.null ()) (Expect.equal [])
-                        |> TestContext.done
+                        |> ProgramTest.assertAndClearOutgoingPortValues "unit" (Decode.null ()) (Expect.equal [ () ])
+                        |> ProgramTest.assertAndClearOutgoingPortValues "unit" (Decode.null ()) (Expect.equal [])
+                        |> ProgramTest.done
             , test "records values in correct order" <|
                 \() ->
                     start (SimulatedEffect.Ports.send "int" (Json.int 5))
-                        |> TestContext.update (ProduceEffects (SimulatedEffect.Ports.send "int" (Json.int 7)))
-                        |> TestContext.assertAndClearOutgoingPortValues "int" Decode.int (Expect.equal [ 5, 7 ])
-                        |> TestContext.done
+                        |> ProgramTest.update (ProduceEffects (SimulatedEffect.Ports.send "int" (Json.int 7)))
+                        |> ProgramTest.assertAndClearOutgoingPortValues "int" Decode.int (Expect.equal [ 5, 7 ])
+                        |> ProgramTest.done
             , test "shows useful error when decoding fails" <|
                 \() ->
                     start (SimulatedEffect.Ports.send "int" (Json.int 5))
-                        |> TestContext.assertAndClearOutgoingPortValues "int" Decode.string (Expect.equal [])
-                        |> TestContext.done
+                        |> ProgramTest.assertAndClearOutgoingPortValues "int" Decode.string (Expect.equal [])
+                        |> ProgramTest.done
                         |> expectFailure
                             [ "assertAndClearOutgoingPortValues: failed to decode port values: Problem with the given value:"
                             , ""
@@ -67,42 +67,42 @@ all =
         , describe "incoming ports" <|
             let
                 startSub f =
-                    TestContext.createElement
+                    ProgramTest.createElement
                         { init = \() -> ( [], SimulatedEffect.Cmd.none )
                         , update = TestingProgram.update
                         , view = \_ -> Html.text ""
                         }
-                        |> TestContext.withSimulatedEffects identity
-                        |> TestContext.withSimulatedSubscriptions f
-                        |> TestContext.start ()
+                        |> ProgramTest.withSimulatedEffects identity
+                        |> ProgramTest.withSimulatedSubscriptions f
+                        |> ProgramTest.start ()
             in
             [ test "simulates incoming ports" <|
                 \() ->
                     startSub (\_ -> SimulatedEffect.Ports.subscribe "int" Decode.int (Debug.toString >> Log))
-                        |> TestContext.simulateIncomingPort "int" (Json.int 7)
-                        |> TestContext.expectModel (Expect.equal [ "7" ])
+                        |> ProgramTest.simulateIncomingPort "int" (Json.int 7)
+                        |> ProgramTest.expectModel (Expect.equal [ "7" ])
             , test "shows useful error when the port is not subscribed to" <|
                 \() ->
                     startSub (\_ -> SimulatedEffect.Sub.none)
-                        |> TestContext.simulateIncomingPort "int" (Json.int 7)
-                        |> TestContext.done
+                        |> ProgramTest.simulateIncomingPort "int" (Json.int 7)
+                        |> ProgramTest.done
                         |> expectFailure [ "simulateIncomingPort \"int\": the program is not currently subscribed to the port" ]
             , test "shows useful error when withSimulatedSubscriptions wasn't used" <|
                 \() ->
-                    TestContext.createElement
+                    ProgramTest.createElement
                         { init = \() -> ( [], SimulatedEffect.Cmd.none )
                         , update = TestingProgram.update
                         , view = \_ -> Html.text ""
                         }
-                        |> TestContext.start ()
-                        |> TestContext.simulateIncomingPort "int" (Json.int 7)
-                        |> TestContext.done
-                        |> expectFailure [ "simulateIncomingPort \"int\": you MUST use TestContext.withSimulatedSubscriptions to be able to use simulateIncomingPort" ]
+                        |> ProgramTest.start ()
+                        |> ProgramTest.simulateIncomingPort "int" (Json.int 7)
+                        |> ProgramTest.done
+                        |> expectFailure [ "simulateIncomingPort \"int\": you MUST use ProgramTest.withSimulatedSubscriptions to be able to use simulateIncomingPort" ]
             , test "shows useful error when decoder fails" <|
                 \() ->
                     startSub (\_ -> SimulatedEffect.Ports.subscribe "int" Decode.int (Debug.toString >> Log))
-                        |> TestContext.simulateIncomingPort "int" (Json.object [])
-                        |> TestContext.done
+                        |> ProgramTest.simulateIncomingPort "int" (Json.object [])
+                        |> ProgramTest.done
                         |> expectFailure
                             [ "simulateIncomingPort \"int\": the value provided does not match the type that the port is expecting:"
                             , "Problem with the given value:"

--- a/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
@@ -1,12 +1,12 @@
-module TestContextTests.UserInput.ClickButtonTest exposing (all)
+module ProgramTestTests.UserInput.ClickButtonTest exposing (all)
 
 import Expect exposing (Expectation)
 import Html
 import Html.Attributes
 import Html.Events exposing (onClick)
+import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
 import Test.Expect exposing (expectFailure)
-import TestContext exposing (TestContext)
 import TestingProgram exposing (Msg(..))
 
 
@@ -20,8 +20,8 @@ all =
                         [ onClick (Log "CLICK") ]
                         [ Html.text "Click Me" ]
                     )
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.expectModel (Expect.equal [ "CLICK" ])
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
         , test "can click an elm-ui button" <|
             \() ->
                 TestingProgram.startView
@@ -31,8 +31,8 @@ all =
                         ]
                         [ Html.text "Click Me" ]
                     )
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.expectModel (Expect.equal [ "CLICK" ])
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
         , test "fails when clicking a disabled button" <|
             \() ->
                 TestingProgram.startView
@@ -42,8 +42,8 @@ all =
                         ]
                         [ Html.text "Click Me" ]
                     )
-                    |> TestContext.clickButton "Click Me"
-                    |> TestContext.done
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.done
                     |> expectFailure
                         [ "clickButton \"Click Me\":"
                         , "▼ Query.fromHtml"

--- a/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
@@ -1,12 +1,12 @@
-module TestContextTests.UserInput.ClickLinkTest exposing (all)
+module ProgramTestTests.UserInput.ClickLinkTest exposing (all)
 
 import Expect
 import Html exposing (Html)
 import Html.Attributes exposing (href)
 import Html.Events
 import Json.Decode
+import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
-import TestContext exposing (TestContext)
 
 
 type TestEffect
@@ -21,9 +21,9 @@ testUpdate msg model =
     )
 
 
-linkProgram : TestContext String String ()
+linkProgram : ProgramTest String String ()
 linkProgram =
-    TestContext.createSandbox
+    ProgramTest.createSandbox
         { init = "<INIT>"
         , update = \msg model -> model ++ ";" ++ msg
         , view =
@@ -33,26 +33,26 @@ linkProgram =
                     , Html.a [ href "/settings" ] [ Html.text "Relative" ]
                     ]
         }
-        |> TestContext.withBaseUrl "http://localhost:3000/Main.elm"
-        |> TestContext.start ()
+        |> ProgramTest.withBaseUrl "http://localhost:3000/Main.elm"
+        |> ProgramTest.start ()
 
 
 all : Test
 all =
-    describe "TestContext.clickLinks"
+    describe "ProgramTest.clickLinks"
         [ test "can verify an absolute link" <|
             \() ->
                 linkProgram
-                    |> TestContext.clickLink "External" "https://example.com/link"
-                    |> TestContext.expectPageChange "https://example.com/link"
+                    |> ProgramTest.clickLink "External" "https://example.com/link"
+                    |> ProgramTest.expectPageChange "https://example.com/link"
         , test "can verify a relative link" <|
             \() ->
                 linkProgram
-                    |> TestContext.clickLink "Relative" "/settings"
-                    |> TestContext.expectPageChange "http://localhost:3000/settings"
+                    |> ProgramTest.clickLink "Relative" "/settings"
+                    |> ProgramTest.expectPageChange "http://localhost:3000/settings"
         , test "can verify an internal (single-page app) link" <|
             \() ->
-                TestContext.createApplication
+                ProgramTest.createApplication
                     { onUrlChange = .path
                     , onUrlRequest = \_ -> Debug.todo "ClickLinkTest:onUrlRequest"
                     , init = \() location key -> ( "<INIT:" ++ location.path ++ ">", NoOp )
@@ -69,10 +69,10 @@ all =
                                 ]
                             }
                     }
-                    |> TestContext.withBaseUrl "http://localhost:3000/"
-                    |> TestContext.start ()
-                    |> TestContext.clickLink "SPA" "#search"
-                    |> TestContext.expectModel (Expect.equal "<INIT:/>;GoToSearch")
+                    |> ProgramTest.withBaseUrl "http://localhost:3000/"
+                    |> ProgramTest.start ()
+                    |> ProgramTest.clickLink "SPA" "#search"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT:/>;GoToSearch")
         ]
 
 

--- a/tests/ProgramTestTests/UserInput/FillInTest.elm
+++ b/tests/ProgramTestTests/UserInput/FillInTest.elm
@@ -1,11 +1,11 @@
-module TestContextTests.UserInput.FillInTest exposing (all)
+module ProgramTestTests.UserInput.FillInTest exposing (all)
 
 import Expect
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, for, id)
 import Html.Events
+import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
-import TestContext exposing (TestContext)
 
 
 handleInput : String -> Html.Attribute String
@@ -13,26 +13,26 @@ handleInput fieldId =
     Html.Events.onInput (\text -> "Input:" ++ fieldId ++ ":" ++ text)
 
 
-start : List (Html String) -> TestContext String String ()
+start : List (Html String) -> ProgramTest String String ()
 start view =
-    TestContext.createSandbox
+    ProgramTest.createSandbox
         { init = "<INIT>"
         , update = \msg model -> model ++ ";" ++ msg
         , view = \_ -> Html.node "body" [] view
         }
-        |> TestContext.start ()
+        |> ProgramTest.start ()
 
 
 all : Test
 all =
-    describe "TestContext.fillIn (and fillInTextArea)"
+    describe "ProgramTest.fillIn (and fillInTextArea)"
         [ test "can simulate textarea input" <|
             \() ->
                 start
                     [ Html.textarea [ handleInput "textarea" ] []
                     ]
-                    |> TestContext.fillInTextarea "ABC"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;Input:textarea:ABC")
+                    |> ProgramTest.fillInTextarea "ABC"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:textarea:ABC")
         , test "can simulate text input on a labeled field" <|
             \() ->
                 start
@@ -41,8 +41,8 @@ all =
                     , Html.label [ for "field-2" ] [ Html.text "Field 2" ]
                     , Html.input [ id "field-2", handleInput "field-2" ] []
                     ]
-                    |> TestContext.fillIn "field-1" "Field 1" "value99"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
+                    |> ProgramTest.fillIn "field-1" "Field 1" "value99"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
         , test "can simulate text input on a labeled textarea" <|
             \() ->
                 start
@@ -51,8 +51,8 @@ all =
                     , Html.label [ for "field-2" ] [ Html.text "Field 2" ]
                     , Html.textarea [ id "field-2", handleInput "field-2" ] []
                     ]
-                    |> TestContext.fillIn "field-1" "Field 1" "value99"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
+                    |> ProgramTest.fillIn "field-1" "Field 1" "value99"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
         , test "can find input contained in the label" <|
             \() ->
                 start
@@ -61,8 +61,8 @@ all =
                         , Html.input [ handleInput "field-1" ] []
                         ]
                     ]
-                    |> TestContext.fillIn "" "Field 1" "value99"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
+                    |> ProgramTest.fillIn "" "Field 1" "value99"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
         , test "can find input with hidden label" <|
             \() ->
                 start
@@ -72,6 +72,6 @@ all =
                         ]
                         []
                     ]
-                    |> TestContext.fillIn "" "Field 1" "value99"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
+                    |> ProgramTest.fillIn "" "Field 1" "value99"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
         ]

--- a/tests/ProgramTestTests/UserInput/SelectOptionTest.elm
+++ b/tests/ProgramTestTests/UserInput/SelectOptionTest.elm
@@ -1,22 +1,22 @@
-module TestContextTests.UserInput.SelectOptionTest exposing (all)
+module ProgramTestTests.UserInput.SelectOptionTest exposing (all)
 
 import Expect exposing (Expectation)
 import Html exposing (Html)
 import Html.Attributes exposing (for, id, value)
 import Html.Events exposing (on)
+import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
 import Test.Runner
-import TestContext exposing (TestContext)
 
 
-testContext : TestContext String String ()
-testContext =
-    TestContext.createSandbox
+start : ProgramTest String String ()
+start =
+    ProgramTest.createSandbox
         { init = "<INIT>"
         , update = \msg model -> model ++ ";" ++ msg
         , view = testView
         }
-        |> TestContext.start ()
+        |> ProgramTest.start ()
 
 
 testView : String -> Html String
@@ -44,17 +44,17 @@ testView model =
 
 all : Test
 all =
-    describe "TestContext.selectionOption"
+    describe "ProgramTest.selectionOption"
         [ test "can select an option" <|
             \() ->
-                testContext
-                    |> TestContext.selectOption "pet-select" "Choose a pet" "hamster-value" "Hamster"
-                    |> TestContext.expectModel (Expect.equal "<INIT>;hamster-value")
+                start
+                    |> ProgramTest.selectOption "pet-select" "Choose a pet" "hamster-value" "Hamster"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;hamster-value")
         , test "fails if there is no onChange handler" <|
             \() ->
-                testContext
-                    |> TestContext.selectOption "name-select" "Choose a name" "george-value" "George"
-                    |> TestContext.done
+                start
+                    |> ProgramTest.selectOption "name-select" "Choose a name" "george-value" "George"
+                    |> ProgramTest.done
                     |> Test.Runner.getFailureReason
                     |> Maybe.map .description
                     |> Maybe.withDefault "<Expected selectOption to fail, but it succeeded>"

--- a/tests/Test/HttpTests.elm
+++ b/tests/Test/HttpTests.elm
@@ -3,11 +3,11 @@ module Test.HttpTests exposing (all)
 import Expect
 import Json.Decode
 import Json.Encode
+import ProgramTest
 import SimulatedEffect.Http as Http
 import Test exposing (..)
 import Test.Expect exposing (expectFailure)
 import Test.Http
-import TestContext
 import TestingProgram exposing (Msg(..))
 
 
@@ -31,10 +31,10 @@ all =
                         , tracker = Nothing
                         }
                     )
-                    |> TestContext.assertHttpRequest "GET"
+                    |> ProgramTest.assertHttpRequest "GET"
                         "https://example.com/ok"
                         (Test.Http.hasHeader "Content-Type" "application/json")
-                    |> TestContext.done
+                    |> ProgramTest.done
                     |> expectFailure
                         [ "assertHttpRequest:"
                         , "Expected HTTP header Content-Type: application/json"
@@ -55,11 +55,11 @@ all =
                         , expect = Http.expectWhatever (Debug.toString >> Log)
                         }
                     )
-                    |> TestContext.assertHttpRequest "POST"
+                    |> ProgramTest.assertHttpRequest "POST"
                         "https://example.com/ok"
                         (Test.Http.expectJsonBody
                             (Json.Decode.field "a" Json.Decode.int)
                             (Expect.equal 8)
                         )
-                    |> TestContext.done
+                    |> ProgramTest.done
         ]

--- a/tests/TestingProgram.elm
+++ b/tests/TestingProgram.elm
@@ -1,44 +1,44 @@
-module TestingProgram exposing (Model, Msg(..), TestContext, application, startEffects, startView, update)
+module TestingProgram exposing (Model, Msg(..), ProgramTest, application, startEffects, startView, update)
 
 {-| This is a generic program for use in tests for many elm-program-test modules.
 -}
 
 import Html exposing (Html)
+import ProgramTest exposing (SimulatedEffect)
 import SimulatedEffect.Cmd
-import TestContext exposing (SimulatedEffect)
 import Url
 
 
-type alias TestContext =
-    TestContext.TestContext Msg Model (SimulatedEffect Msg)
+type alias ProgramTest =
+    ProgramTest.ProgramTest Msg Model (SimulatedEffect Msg)
 
 
-startEffects : SimulatedEffect Msg -> TestContext
+startEffects : SimulatedEffect Msg -> ProgramTest
 startEffects initialEffect =
     start initialEffect (Html.text "")
 
 
-startView : Html Msg -> TestContext
+startView : Html Msg -> ProgramTest
 startView =
     start SimulatedEffect.Cmd.none
 
 
-start : SimulatedEffect Msg -> Html Msg -> TestContext
+start : SimulatedEffect Msg -> Html Msg -> ProgramTest
 start initialEffect html =
-    TestContext.createElement
+    ProgramTest.createElement
         { init = \() -> ( [], initialEffect )
         , update = update
         , view = \_ -> Html.node "body" [] [ html ]
         }
-        |> TestContext.withSimulatedEffects identity
-        |> TestContext.start ()
+        |> ProgramTest.withSimulatedEffects identity
+        |> ProgramTest.start ()
 
 
-application : SimulatedEffect Msg -> TestContext
+application : SimulatedEffect Msg -> ProgramTest
 application initialEffects =
-    TestContext.createApplication
+    ProgramTest.createApplication
         { onUrlChange = \location -> Log (Url.toString location)
-        , onUrlRequest = \_ -> Debug.todo "TestContextTests-2:onUrlRequest"
+        , onUrlRequest = \_ -> Debug.todo "ProgramTestTests-2:onUrlRequest"
         , init = \() location key -> ( [], initialEffects )
         , update = update
         , view =
@@ -47,9 +47,9 @@ application initialEffects =
                 , body = []
                 }
         }
-        |> TestContext.withSimulatedEffects identity
-        |> TestContext.withBaseUrl "https://example.com/path"
-        |> TestContext.start ()
+        |> ProgramTest.withSimulatedEffects identity
+        |> ProgramTest.withBaseUrl "https://example.com/path"
+        |> ProgramTest.start ()
 
 
 type alias Model =


### PR DESCRIPTION
Fixes https://github.com/avh4/elm-program-test/issues/5

Documentation can be previewed here:
- API docs: https://elm-doc-preview.netlify.com?repo=avh4/elm-program-test&version=big-rename-docs
- guides: https://deploy-preview-33--elm-program-test.netlify.com/

