### PR TITLE
fillIn works with a specified id and aria-label, and more consistent …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## 3.2.0
 
 New features:
+
   - added `ProgramTest.expectBrowserUrl`
   - added `ProgramTest.expectBrowserHistory`
+  
+Bug fixes:
+
+  - `fillIn` will now work when the target input has both an `aria-label` and an `id`
 
 
 ## 3.1.0

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -695,54 +695,52 @@ simulateLabeledInputHelper functionDescription fieldId label allowTextArea addit
                 checks_ "an" "input"
 
         checks_ article inputTag =
-            List.concat
-                [ if fieldId == "" then
-                    [ ( "a <label> with text " ++ escapeString label ++ " containing " ++ article ++ " <" ++ inputTag ++ ">"
-                      , simulateHelper functionDescription
-                            (Query.find
-                                [ Selector.tag "label"
-                                , Selector.containing [ Selector.text label ]
-                                ]
-                                >> Query.find [ Selector.tag inputTag ]
-                            )
-                            event
-                      )
-                    , ( "<" ++ inputTag ++ " aria-label=" ++ escapeString label ++ ">"
-                      , simulateHelper functionDescription
-                            (Query.find
-                                [ Selector.tag inputTag
-                                , Selector.attribute (attribute "aria-label" label)
-                                ]
-                            )
-                            event
-                      )
-                    ]
+            if fieldId == "" then
+                [ ( "a <label> with text " ++ escapeString label ++ " containing " ++ article ++ " <" ++ inputTag ++ ">"
+                  , simulateHelper functionDescription
+                        (Query.find
+                            [ Selector.tag "label"
+                            , Selector.containing [ Selector.text label ]
+                            ]
+                            >> Query.find [ Selector.tag inputTag ]
+                        )
+                        event
+                  )
+                , ( "<" ++ inputTag ++ " aria-label=" ++ escapeString label ++ ">"
+                  , simulateHelper functionDescription
+                        (Query.find
+                            [ Selector.tag inputTag
+                            , Selector.attribute (attribute "aria-label" label)
+                            ]
+                        )
+                        event
+                  )
+                ]
 
-                  else
-                    [ ( "<label for=" ++ escapeString fieldId ++ "> with text " ++ escapeString label ++ " and " ++ article ++ " <" ++ inputTag ++ " id=" ++ escapeString fieldId ++ ">"
-                      , associatedLabel
-                            >> simulateHelper functionDescription
-                                (Query.find <|
-                                    List.concat
-                                        [ [ Selector.tag inputTag
-                                          , Selector.id fieldId
-                                          ]
-                                        , additionalInputSelectors
-                                        ]
-                                )
-                                event
-                      )
-                    , ( "<" ++ inputTag ++ " aria-label=" ++ escapeString label ++ " id=" ++ escapeString fieldId ++ ">"
-                      , simulateHelper functionDescription
-                            (Query.find
-                                [ Selector.tag inputTag
-                                , Selector.id fieldId
-                                , Selector.attribute (attribute "aria-label" label)
-                                ]
+            else
+                [ ( "<label for=" ++ escapeString fieldId ++ "> with text " ++ escapeString label ++ " and " ++ article ++ " <" ++ inputTag ++ " id=" ++ escapeString fieldId ++ ">"
+                  , associatedLabel
+                        >> simulateHelper functionDescription
+                            (Query.find <|
+                                List.concat
+                                    [ [ Selector.tag inputTag
+                                      , Selector.id fieldId
+                                      ]
+                                    , additionalInputSelectors
+                                    ]
                             )
                             event
-                      )
-                    ]
+                  )
+                , ( "<" ++ inputTag ++ " aria-label=" ++ escapeString label ++ " id=" ++ escapeString fieldId ++ ">"
+                  , simulateHelper functionDescription
+                        (Query.find
+                            [ Selector.tag inputTag
+                            , Selector.id fieldId
+                            , Selector.attribute (attribute "aria-label" label)
+                            ]
+                        )
+                        event
+                  )
                 ]
     in
     expectOneOfManyViewChecks

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -676,56 +676,118 @@ a future release of this package will remove the `fieldId` parameter.
 -}
 simulateLabeledInputHelper : String -> String -> String -> Bool -> List Selector -> ( String, Json.Encode.Value ) -> ProgramTest model msg effect -> ProgramTest model msg effect
 simulateLabeledInputHelper functionDescription fieldId label allowTextArea additionalInputSelectors event programTest =
-    programTest
-        |> (if fieldId == "" then
-                identity
+    let
+        associatedLabel =
+            expectViewHelper functionDescription
+                (Query.find
+                    [ Selector.tag "label"
+                    , Selector.attribute (Html.Attributes.for fieldId)
+                    , Selector.text label
+                    ]
+                    >> Query.has []
+                )
+
+        checks =
+            if allowTextArea then
+                checks_ "an" "input" ++ checks_ "a" "textarea"
 
             else
-                expectViewHelper functionDescription
-                    (Query.find
-                        [ Selector.tag "label"
-                        , Selector.attribute (Html.Attributes.for fieldId)
-                        , Selector.text label
-                        ]
-                        >> Query.has []
-                    )
-           )
-        |> simulateHelper functionDescription
-            (Query.Extra.oneOf <|
-                List.concat
-                    [ if fieldId == "" then
-                        [ Query.find
-                            [ Selector.tag "label"
-                            , Selector.containing [ Selector.text label ]
-                            ]
-                            >> Query.find [ Selector.tag "input" ]
-                        , Query.find
-                            [ Selector.tag "input"
-                            , Selector.attribute (attribute "aria-label" label)
-                            ]
-                        ]
+                checks_ "an" "input"
 
-                      else
-                        [ Query.find <|
-                            List.concat
-                                [ [ Selector.tag "input"
-                                  , Selector.id fieldId
-                                  ]
-                                , additionalInputSelectors
+        checks_ article inputTag =
+            List.concat
+                [ if fieldId == "" then
+                    [ ( "a <label> with text " ++ escapeString label ++ " containing " ++ article ++ " <" ++ inputTag ++ ">"
+                      , simulateHelper functionDescription
+                            (Query.find
+                                [ Selector.tag "label"
+                                , Selector.containing [ Selector.text label ]
                                 ]
-                        ]
-                    , if allowTextArea then
-                        [ Query.find
-                            [ Selector.tag "textarea"
-                            , Selector.id fieldId
-                            ]
-                        ]
-
-                      else
-                        []
+                                >> Query.find [ Selector.tag inputTag ]
+                            )
+                            event
+                      )
+                    , ( "<" ++ inputTag ++ " aria-label=" ++ escapeString label ++ ">"
+                      , simulateHelper functionDescription
+                            (Query.find
+                                [ Selector.tag inputTag
+                                , Selector.attribute (attribute "aria-label" label)
+                                ]
+                            )
+                            event
+                      )
                     ]
-            )
-            event
+
+                  else
+                    [ ( "<label for=" ++ escapeString fieldId ++ "> with text " ++ escapeString label ++ " and " ++ article ++ " <" ++ inputTag ++ " id=" ++ escapeString fieldId ++ ">"
+                      , associatedLabel
+                            >> simulateHelper functionDescription
+                                (Query.find <|
+                                    List.concat
+                                        [ [ Selector.tag inputTag
+                                          , Selector.id fieldId
+                                          ]
+                                        , additionalInputSelectors
+                                        ]
+                                )
+                                event
+                      )
+                    , ( "<" ++ inputTag ++ " aria-label=" ++ escapeString label ++ " id=" ++ escapeString fieldId ++ ">"
+                      , simulateHelper functionDescription
+                            (Query.find
+                                [ Selector.tag inputTag
+                                , Selector.id fieldId
+                                , Selector.attribute (attribute "aria-label" label)
+                                ]
+                            )
+                            event
+                      )
+                    ]
+                ]
+    in
+    expectOneOfManyViewChecks
+        functionDescription
+        ("Expected one of the following to exist and have an " ++ escapeString ("on" ++ Tuple.first event) ++ " handler")
+        checks
+        programTest
+
+
+{-| TODO: have other internal functions use this to have more consistent error message.
+-}
+expectOneOfManyViewChecks :
+    String
+    -> String
+    -> List ( String, ProgramTest model msg effect -> ProgramTest model msg effect )
+    -> ProgramTest model msg effect
+    -> ProgramTest model msg effect
+expectOneOfManyViewChecks functionDescription errorMessage checks programTest =
+    let
+        oneOf items =
+            case items of
+                [] ->
+                    failWithViewError functionDescription
+                        (String.join "\n" <|
+                            List.concat
+                                [ [ errorMessage ++ ":" ]
+                                , List.map (\check_ -> "- " ++ Tuple.first check_) checks
+                                ]
+                        )
+                        programTest
+
+                next :: rest ->
+                    let
+                        newProgramTest =
+                            next programTest
+                    in
+                    case Test.Runner.getFailureReason (done newProgramTest) of
+                        Nothing ->
+                            -- the check passed
+                            newProgramTest
+
+                        Just _ ->
+                            oneOf rest
+    in
+    oneOf (List.map Tuple.second checks)
 
 
 {-| Simulates a custom DOM event.
@@ -2304,6 +2366,44 @@ fail assertionName failureMessage programTest =
 
         Active _ ->
             Finished (CustomFailure assertionName failureMessage)
+
+
+{-| This is meant for internal use only and adds a rendering of the current view to an error message.
+-}
+failWithViewError : String -> String -> ProgramTest model msg effect -> ProgramTest model msg effect
+failWithViewError functionDescription errorMessage programTest =
+    -- This is a big hack to grab the rendered HTML for the error message,
+    -- since Test.Html.Query doesn't expose a way to get the HTML as a string
+    -- or to compose custom error messages
+    case programTest of
+        Finished err ->
+            Finished err
+
+        Active state ->
+            let
+                renderHtml unique =
+                    case
+                        state.currentModel
+                            |> state.program.view
+                            |> Query.has [ Selector.text ("HTML expected by the call to: " ++ functionDescription ++ unique) ]
+                            |> Test.Runner.getFailureReason
+                    of
+                        Nothing ->
+                            -- We expect the fake query to fail -- if it doesn't for some reason, just try recursing with a different fake matchin string until it does fail
+                            renderHtml (unique ++ "_")
+
+                        Just reason ->
+                            reason.description
+            in
+            programTest
+                |> fail functionDescription
+                    (String.join "\n"
+                        [ ""
+                        , renderHtml ""
+                        , ""
+                        , errorMessage
+                        ]
+                    )
 
 
 {-| `createFailed` can be used to report custom errors if you are writing your own convenience functions to _create_ program tests.

--- a/tests/ProgramTestTests/UserInput/FillInTest.elm
+++ b/tests/ProgramTestTests/UserInput/FillInTest.elm
@@ -6,6 +6,7 @@ import Html.Attributes exposing (attribute, for, id)
 import Html.Events
 import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
+import Test.Expect exposing (expectFailure)
 
 
 handleInput : String -> Html.Attribute String
@@ -74,4 +75,40 @@ all =
                     ]
                     |> ProgramTest.fillIn "" "Field 1" "value99"
                     |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
+        , test "can find input with aria-label and an id" <|
+            \() ->
+                start
+                    [ Html.input
+                        [ handleInput "field-1"
+                        , attribute "aria-label" "Field 1"
+                        , id "field-id"
+                        ]
+                        []
+                    ]
+                    |> ProgramTest.fillIn "field-id" "Field 1" "value99"
+                    |> ProgramTest.expectModel (Expect.equal "<INIT>;Input:field-1:value99")
+        , test "shows a useful error when the input doesn't exist" <|
+            \() ->
+                start [ Html.text "no input" ]
+                    |> ProgramTest.fillIn "field-id" "Field 1" "value99"
+                    |> ProgramTest.done
+                    |> expectFailure
+                        [ """fillIn "Field 1": """
+                        , "▼ Query.fromHtml"
+                        , ""
+                        , "    <body>"
+                        , "        no input"
+                        , "    </body>"
+                        , ""
+                        , ""
+                        , """▼ Query.has [ text "HTML expected by the call to: fillIn "Field 1"" ]"""
+                        , ""
+                        , """✗ has text "HTML expected by the call to: fillIn "Field 1\"\""""
+                        , ""
+                        , "Expected one of the following to exist and have an \"oninput\" handler:"
+                        , """- <label for="field-id"> with text "Field 1" and an <input id="field-id">"""
+                        , """- <input aria-label="Field 1" id="field-id">"""
+                        , """- <label for="field-id"> with text "Field 1" and a <textarea id="field-id">"""
+                        , """- <textarea aria-label="Field 1" id="field-id">"""
+                        ]
         ]


### PR DESCRIPTION
Fixes https://github.com/avh4/elm-program-test/issues/79 and starts setting up helper functions for making error messages more detailed and more consistent, and improves the error messages for `fillIn`.