### PR TITLE
Choosing options in selects without label text

### DIFF
--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -204,8 +204,7 @@ import Json.Decode
 import Json.Encode
 import PairingHeap
 import ProgramTest.EffectSimulation as EffectSimulation exposing (EffectSimulation)
-import Query.Extra
-import SimulatedEffect exposing (SimulatedEffect, SimulatedSub, SimulatedTask)
+import SimulatedEffect exposing (SimulatedEffect, SimulatedSub)
 import Test.Html.Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector exposing (Selector)

--- a/tests/ProgramTestTests/UserInput/SelectOptionTest.elm
+++ b/tests/ProgramTestTests/UserInput/SelectOptionTest.elm
@@ -39,6 +39,15 @@ testView model =
             [ Html.option [ value "hamster-value" ] [ Html.text "Hamster" ]
             , Html.option [ value "george-value" ] [ Html.text "George" ]
             ]
+        , Html.label [ for "no-text-select" ]
+            [ Html.select
+                [ id "no-text-select"
+                , on "change" Html.Events.targetValue
+                ]
+                [ Html.option [ value "foo-value" ] [ Html.text "Foo" ]
+                , Html.option [ value "bar-value" ] [ Html.text "Bar" ]
+                ]
+            ]
         ]
 
 
@@ -50,6 +59,13 @@ all =
                 start
                     |> ProgramTest.selectOption "pet-select" "Choose a pet" "hamster-value" "Hamster"
                     |> ProgramTest.expectModel (Expect.equal "<INIT>;hamster-value")
+        , test "it finds only elements that match all the query criteria" <|
+            \() ->
+                start
+                    |> ProgramTest.selectOption "no-text-select" "" "foo-value" "Foo"
+                    |> ProgramTest.done
+                    |> Test.Runner.getFailureReason
+                    |> Expect.equal Maybe.Nothing
         , test "fails if there is no onChange handler" <|
             \() ->
                 start

--- a/tests/ProgramTestTests/UserInput/SelectOptionTest.elm
+++ b/tests/ProgramTestTests/UserInput/SelectOptionTest.elm
@@ -5,7 +5,7 @@ import Html exposing (Html)
 import Html.Attributes exposing (for, id, value)
 import Html.Events exposing (on)
 import ProgramTest exposing (ProgramTest)
-import Test exposing (..)
+import Test exposing (Test, describe, test)
 import Test.Runner
 
 
@@ -20,7 +20,7 @@ start =
 
 
 testView : String -> Html String
-testView model =
+testView _ =
     Html.div []
         [ Html.label [ for "pet-select" ] [ Html.text "Choose a pet" ]
         , Html.select


### PR DESCRIPTION
This is a reproducing testcase for #92. I was unable to make it pass quickly by slapping a bunch of `Selector.all` in there, so some discussion could probably help. Greetings and thanks!