### PR TITLE
clickButton supports buttons with aria-label

### DIFF
--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -854,6 +854,15 @@ clickButton buttonText programTest =
                     )
                     Test.Html.Event.click
               )
+            , ( "an element with role=\"button\" (not disabled) and onClick and aria-label=" ++ escapeString buttonText
+              , simulateHelper functionDescription
+                    (findNotDisabled
+                        [ Selector.attribute (Html.Attributes.attribute "role" "button")
+                        , Selector.attribute (Html.Attributes.attribute "aria-label" buttonText)
+                        ]
+                    )
+                    Test.Html.Event.click
+              )
             , ( "a <form> with onSubmit containing a <button> (not disabled, not type=button) with text " ++ escapeString buttonText
               , simulateHelper functionDescription
                     (findButNot

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -836,6 +836,15 @@ clickButton buttonText programTest =
                     )
                     Test.Html.Event.click
               )
+            , ( "<button> (not disabled) with onClick and attribute aria-label=" ++ escapeString buttonText
+              , simulateHelper functionDescription
+                    (findNotDisabled
+                        [ Selector.tag "button"
+                        , Selector.attribute (Html.Attributes.attribute "aria-label" buttonText)
+                        ]
+                    )
+                    Test.Html.Event.click
+              )
             , ( "an element with role=\"button\" (not disabled) and onClick and text " ++ escapeString buttonText
               , simulateHelper functionDescription
                     (findNotDisabled

--- a/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
@@ -33,6 +33,18 @@ all =
                     )
                     |> ProgramTest.clickButton "Close"
                     |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
+        , test "can click a role=\"button\" with an aria-label attribute" <|
+            \() ->
+                TestingProgram.startView
+                    (Html.div
+                        [ onClick (Log "CLICK")
+                        , attribute "role" "button"
+                        , attribute "aria-label" "Close"
+                        ]
+                        [ Html.text "X" ]
+                    )
+                    |> ProgramTest.clickButton "Close"
+                    |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
         , test "can click an elm-ui button" <|
             \() ->
                 TestingProgram.startView
@@ -119,6 +131,7 @@ all =
                         , "- <button> (not disabled) with onClick and text \"Click Me\""
                         , "- <button> (not disabled) with onClick and attribute aria-label=\"Click Me\""
                         , "- an element with role=\"button\" (not disabled) and onClick and text \"Click Me\""
+                        , "- an element with role=\"button\" (not disabled) and onClick and aria-label=\"Click Me\""
                         , "- a <form> with onSubmit containing a <button> (not disabled, not type=button) with text \"Click Me\""
                         , "- a <form> with onSubmit containing an <input type=submit value=\"Click Me\"> (not disabled)"
                         ]

--- a/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
@@ -2,7 +2,7 @@ module ProgramTestTests.UserInput.ClickButtonTest exposing (all)
 
 import Expect exposing (Expectation)
 import Html
-import Html.Attributes exposing (disabled, type_, value)
+import Html.Attributes exposing (attribute, disabled, type_, value)
 import Html.Events exposing (onClick, onSubmit)
 import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
@@ -21,6 +21,17 @@ all =
                         [ Html.text "Click Me" ]
                     )
                     |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
+        , test "can click a button with an aria-label attribute" <|
+            \() ->
+                TestingProgram.startView
+                    (Html.button
+                        [ onClick (Log "CLICK")
+                        , attribute "aria-label" "Close"
+                        ]
+                        [ Html.text "X" ]
+                    )
+                    |> ProgramTest.clickButton "Close"
                     |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
         , test "can click an elm-ui button" <|
             \() ->
@@ -106,6 +117,7 @@ all =
                         , ""
                         , "Expected one of the following to exist:"
                         , "- <button> (not disabled) with onClick and text \"Click Me\""
+                        , "- <button> (not disabled) with onClick and attribute aria-label=\"Click Me\""
                         , "- an element with role=\"button\" (not disabled) and onClick and text \"Click Me\""
                         , "- a <form> with onSubmit containing a <button> (not disabled, not type=button) with text \"Click Me\""
                         , "- a <form> with onSubmit containing an <input type=submit value=\"Click Me\"> (not disabled)"


### PR DESCRIPTION
I was writing some tests around a `<button />` that had an `aria-label` attribute and noticed that `clickButton` wasn't able to find it. This adds extra checks for any buttons or elements with `role="button"` that have an `aria-label` that matches the string passed to `clickButton`.

One thing to make sure is that this is even a valid way to encourage people to use `aria-label`. After doing some reading, I _think_ it is. Inspecting the `aria-label` button that I previously mentioned and comparing it to a normal button with a text node in Firefox's accessibility tools shows essentially the properties. In other words, I think that it would be presented to a user using accessibility tools in the same way, which is what we want!

I was also curious how other similar tools handle `aria-label`, and took a look at capybara. They also [added support](https://github.com/teamcapybara/capybara/pull/1732#issue-79971772) for it a few years ago. However, you need to opt in with [`enable_aria_label`](https://github.com/teamcapybara/capybara/blob/master/lib/capybara.rb#L83).

There's also the question of whether _all_ elements (like inputs) should also have this enabled. For now, I was just focusing on my button case, but maybe worth thinking about now.