### PR TITLE
Add simulation for more navigation cmds

### DIFF
--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -1088,11 +1088,11 @@ clickLink linkText href programTest =
             (findLinkTag
                 >> Query.has []
             )
-        |> tryClicking { otherwise = followLink functionDescription href }
+        |> tryClicking { otherwise = simulateLoadUrlHelper functionDescription href }
 
 
-followLink : String -> String -> ProgramTest model msg effect -> ProgramTest model msg effect
-followLink functionDescription href programTest =
+simulateLoadUrlHelper : String -> String -> ProgramTest model msg effect -> ProgramTest model msg effect
+simulateLoadUrlHelper functionDescription href programTest =
     case programTest of
         Finished err ->
             Finished err
@@ -1105,7 +1105,7 @@ followLink functionDescription href programTest =
                 Nothing ->
                     case Url.fromString href of
                         Nothing ->
-                            Finished (NoBaseUrl "clickLink" href)
+                            Finished (NoBaseUrl functionDescription href)
 
                         Just location ->
                             Finished (ChangedPage functionDescription location)
@@ -1448,6 +1448,9 @@ queueSimulatedEffect effect programTest =
                                             Just first ->
                                                 programTest
                                                     |> routeChangeHelper ("simulating effect: SimulatedEffect.Navigation.Back " ++ String.fromInt n) 2 (Url.toString first)
+
+                        SimulatedEffect.Load url ->
+                            simulateLoadUrlHelper ("simulating effect: SimulatedEffect.Navigation.load " ++ url) url programTest
 
 
 drain : ProgramTest model msg effect -> ProgramTest model msg effect

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -20,6 +20,7 @@ module ProgramTest exposing
     , expectOutgoingPortValues, ensureOutgoingPortValues
     , simulateIncomingPort
     , expectPageChange, expectBrowserUrl, expectBrowserHistory
+    , expectPageReload, expectPageReloadWithoutCache
     , ensureBrowserUrl, ensureBrowserHistory
     , routeChange
     , update
@@ -160,6 +161,7 @@ The following functions allow you to configure your
 ## Browser assertions
 
 @docs expectPageChange, expectBrowserUrl, expectBrowserHistory
+@docs expectPageReload, expectPageReloadWithoutCache
 @docs ensureBrowserUrl, ensureBrowserHistory
 
 
@@ -251,6 +253,7 @@ type alias TestProgram model msg effect sub =
 
 type Failure
     = ChangedPage String Url
+    | ReloadedPage String Bool
       -- Errors
     | ExpectFailed String String Test.Runner.Failure.Reason
     | SimulateFailed String String
@@ -1452,6 +1455,17 @@ queueSimulatedEffect effect programTest =
                         SimulatedEffect.Load url ->
                             simulateLoadUrlHelper ("simulating effect: SimulatedEffect.Navigation.load " ++ url) url programTest
 
+                        SimulatedEffect.Reload skipCache ->
+                            let
+                                functionName =
+                                    if skipCache then
+                                        "reloadAndSkipCache"
+
+                                    else
+                                        "reload"
+                            in
+                            Finished (ReloadedPage ("simulating effect: SimulatedEffect.Navigation." ++ functionName) skipCache)
+
 
 drain : ProgramTest model msg effect -> ProgramTest model msg effect
 drain =
@@ -2268,6 +2282,9 @@ done programTest =
         Finished (ChangedPage cause finalLocation) ->
             Expect.fail (cause ++ " caused the program to end by navigating to " ++ escapeString (Url.toString finalLocation) ++ ".  NOTE: If this is what you intended, use ProgramTest.expectPageChange to end your test.")
 
+        Finished (ReloadedPage cause _) ->
+            Expect.fail (cause ++ " caused the program to end by reloading. NOTE: If this is what you intended, use ProgramTest.expectPageReload to end your test.")
+
         Finished (ExpectFailed expectationName description reason) ->
             Expect.fail (expectationName ++ ":\n" ++ Test.Runner.Failure.format description reason)
 
@@ -2343,6 +2360,46 @@ expectPageChange expectedUrl programTest =
 
         Active _ ->
             Expect.fail "expectPageChange: expected to have navigated to a different URL, but no links were clicked"
+
+
+{-| Asserts that the program ended by reloading the current page.
+-}
+expectPageReload : ProgramTest model msg effect -> Expectation
+expectPageReload programTest =
+    case programTest of
+        Finished (ReloadedPage _ False) ->
+            Expect.pass
+
+        Finished (ReloadedPage _ True) ->
+            Expect.fail "expectPageReload: the page was reloaded, but the cache was skipped! If this was intentional, use ProgramTest.expectPageReloadWithoutCache instead."
+
+        Finished _ ->
+            programTest |> done
+
+        Active _ ->
+            Expect.fail "expectPageReload: expected to have reloaded the page, but no cmd was sent"
+
+
+{-| Asserts that the program ended by reloading the current page, without using the browser cache.
+
+It is more likely that you want [`expectPageReload`](#expectPageReload), unless you know that you want
+to be skipping the cache.
+
+-}
+expectPageReloadWithoutCache : ProgramTest model msg effect -> Expectation
+expectPageReloadWithoutCache programTest =
+    case programTest of
+        Finished (ReloadedPage _ True) ->
+            Expect.pass
+
+        Finished (ReloadedPage _ False) ->
+            Expect.fail "expectPageReloadWithoutCache: the page was reloaded, but the cache was not skipped! If this was intentional, use ProgramTest.expectPageReload instead."
+
+        Finished _ ->
+            programTest |> done
+
+        Active _ ->
+            Expect.fail "expectPageReloadWithoutCache: expected to have reloaded the page, but no cmd was sent"
 
 
 {-| Asserts on the current value of the browser URL bar in the simulated test environment.

--- a/src/SimulatedEffect.elm
+++ b/src/SimulatedEffect.elm
@@ -14,6 +14,7 @@ type SimulatedEffect msg
     | PushUrl String
     | ReplaceUrl String
     | Back Int
+    | Load String
 
 
 type SimulatedTask x a

--- a/src/SimulatedEffect.elm
+++ b/src/SimulatedEffect.elm
@@ -15,6 +15,7 @@ type SimulatedEffect msg
     | ReplaceUrl String
     | Back Int
     | Load String
+    | Reload Bool
 
 
 type SimulatedTask x a

--- a/src/SimulatedEffect/Cmd.elm
+++ b/src/SimulatedEffect/Cmd.elm
@@ -63,3 +63,6 @@ map f effect =
 
         SimulatedEffect.Load url ->
             SimulatedEffect.Load url
+
+        SimulatedEffect.Reload skipCache ->
+            SimulatedEffect.Reload skipCache

--- a/src/SimulatedEffect/Cmd.elm
+++ b/src/SimulatedEffect/Cmd.elm
@@ -60,3 +60,6 @@ map f effect =
 
         SimulatedEffect.Back n ->
             SimulatedEffect.Back n
+
+        SimulatedEffect.Load url ->
+            SimulatedEffect.Load url

--- a/src/SimulatedEffect/Navigation.elm
+++ b/src/SimulatedEffect/Navigation.elm
@@ -1,4 +1,7 @@
-module SimulatedEffect.Navigation exposing (pushUrl, replaceUrl, back)
+module SimulatedEffect.Navigation exposing
+    ( pushUrl, replaceUrl, back
+    , load
+    )
 
 {-| This module parallels [elm/browsers's `Browser.Navigation` module](https://package.elm-lang.org/packages/elm/browser/1.0.1/Browser-Navigation).
 _Pull requests are welcome to add any functions that are missing._
@@ -10,6 +13,11 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 # Navigate within Page
 
 @docs pushUrl, replaceUrl, back
+
+
+# Navigate to other Pages
+
+@docs load
 
 -}
 
@@ -37,3 +45,10 @@ replaceUrl =
 back : Int -> SimulatedEffect msg
 back =
     SimulatedEffect.Back
+
+
+{-| Leave the current page and load the given URL.
+-}
+load : String -> SimulatedEffect msg
+load =
+    SimulatedEffect.Load

--- a/src/SimulatedEffect/Navigation.elm
+++ b/src/SimulatedEffect/Navigation.elm
@@ -1,6 +1,6 @@
 module SimulatedEffect.Navigation exposing
     ( pushUrl, replaceUrl, back
-    , load
+    , load, reload, reloadAndSkipCache
     )
 
 {-| This module parallels [elm/browsers's `Browser.Navigation` module](https://package.elm-lang.org/packages/elm/browser/1.0.1/Browser-Navigation).
@@ -17,7 +17,7 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 
 # Navigate to other Pages
 
-@docs load
+@docs load, reload, reloadAndSkipCache
 
 -}
 
@@ -52,3 +52,17 @@ back =
 load : String -> SimulatedEffect msg
 load =
     SimulatedEffect.Load
+
+
+{-| Reload the current page.
+-}
+reload : SimulatedEffect msg
+reload =
+    SimulatedEffect.Reload False
+
+
+{-| Reload the current page without using the browser cache.
+-}
+reloadAndSkipCache : SimulatedEffect msg
+reloadAndSkipCache =
+    SimulatedEffect.Reload True

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -6,6 +6,7 @@ import ProgramTest
 import SimulatedEffect.Cmd
 import SimulatedEffect.Navigation
 import Test exposing (..)
+import Test.Expect exposing (expectFailure)
 import TestingProgram exposing (Msg(..))
 
 
@@ -106,8 +107,22 @@ all =
             \() ->
                 TestingProgram.application SimulatedEffect.Navigation.reload
                     |> ProgramTest.expectPageReload
+        , test "reloading a page with cache and asserting the cache was skipped" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.Navigation.reload
+                    |> ProgramTest.expectPageReloadWithoutCache
+                    |> expectFailure
+                        [ "expectPageReloadWithoutCache: the page was reloaded, but the cache was not skipped! If this was intentional, use ProgramTest.expectPageReload instead."
+                        ]
         , test "reloading a page and skipping the cache" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Navigation.reloadAndSkipCache
                     |> ProgramTest.expectPageReloadWithoutCache
+        , test "reloading a page wthout cache and asserting the cache was not skipped" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.Navigation.reloadAndSkipCache
+                    |> ProgramTest.expectPageReload
+                    |> expectFailure
+                        [ "expectPageReload: the page was reloaded, but the cache was skipped! If this was intentional, use ProgramTest.expectPageReloadWithoutCache instead."
+                        ]
         ]

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -118,7 +118,7 @@ all =
             \() ->
                 TestingProgram.application SimulatedEffect.Navigation.reloadAndSkipCache
                     |> ProgramTest.expectPageReloadWithoutCache
-        , test "reloading a page wthout cache and asserting the cache was not skipped" <|
+        , test "reloading a page without cache and asserting the cache was not skipped" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Navigation.reloadAndSkipCache
                     |> ProgramTest.expectPageReload

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -102,4 +102,12 @@ all =
             \() ->
                 TestingProgram.application (SimulatedEffect.Navigation.load "https://example.com")
                     |> ProgramTest.expectPageChange "https://example.com/"
+        , test "reloading a page" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.Navigation.reload
+                    |> ProgramTest.expectPageReload
+        , test "reloading a page and skipping the cache" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.Navigation.reloadAndSkipCache
+                    |> ProgramTest.expectPageReloadWithoutCache
         ]

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -98,4 +98,8 @@ all =
                 TestingProgram.application (SimulatedEffect.Navigation.pushUrl "https://example.com/new")
                     |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.back 0))
                     |> ProgramTest.expectBrowserUrl (Expect.equal "https://example.com/new")
+        , test "simulate loading a page" <|
+            \() ->
+                TestingProgram.application (SimulatedEffect.Navigation.load "https://example.com")
+                    |> ProgramTest.expectPageChange "https://example.com/"
         ]


### PR DESCRIPTION
Ran into a case today where I needed `load`, so I decided look into adding it. I also found #39, so I added `reload` and `reloadAndSkipCache` while I was there.

Note that I ended up adding new assertions for page reloads specifically. Right now, `expectPageChange` will always fail if there was a reload. I think it makes sense (the page didn't change), but I could also be convinced that it should pass if the Url was the same as the one when the `reload` command was sent.

The `ReloadedPage` case in `Failure` could easily be updated to save the current Url, and then `expectPageChange` can make a comparison in those cases. Let me know if that's worth adding!