### PR TITLE
Expose types that are used in the public API

### DIFF
--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -1443,7 +1443,7 @@ If you want to interact with the program more after this assertion, see [`ensure
 expectHttpRequest :
     String
     -> String
-    -> (SimulatedEffect.HttpRequest msg msg -> Expectation)
+    -> (Test.Http.HttpRequest msg msg -> Expectation)
     -> ProgramTest model msg effect
     -> Expectation
 expectHttpRequest method url checkRequest =
@@ -1462,7 +1462,7 @@ as having a single assertion per test can make the intent of your tests more cle
 ensureHttpRequest :
     String
     -> String
-    -> (SimulatedEffect.HttpRequest msg msg -> Expectation)
+    -> (Test.Http.HttpRequest msg msg -> Expectation)
     -> ProgramTest model msg effect
     -> ProgramTest model msg effect
 ensureHttpRequest method url checkRequest =
@@ -1473,7 +1473,7 @@ expectHttpRequestHelper :
     String
     -> String
     -> String
-    -> (SimulatedEffect.HttpRequest msg msg -> Expectation)
+    -> (Test.Http.HttpRequest msg msg -> Expectation)
     -> TestState model msg effect
     -> Result Failure (TestState model msg effect)
 expectHttpRequestHelper functionName method url checkRequest state =

--- a/src/SimulatedEffect/Cmd.elm
+++ b/src/SimulatedEffect/Cmd.elm
@@ -14,7 +14,8 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 
 -}
 
-import SimulatedEffect exposing (SimulatedEffect)
+import ProgramTest exposing (SimulatedEffect)
+import SimulatedEffect
 import SimulatedEffect.Task as Task
 
 

--- a/src/SimulatedEffect/Http.elm
+++ b/src/SimulatedEffect/Http.elm
@@ -48,7 +48,8 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 import Http
 import Json.Decode exposing (Decoder)
 import Json.Encode
-import SimulatedEffect as SimulatedEffect exposing (SimulatedEffect, SimulatedTask)
+import ProgramTest exposing (SimulatedEffect, SimulatedTask)
+import SimulatedEffect
 
 
 {-| Create a `GET` request.

--- a/src/SimulatedEffect/Navigation.elm
+++ b/src/SimulatedEffect/Navigation.elm
@@ -21,7 +21,8 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 
 -}
 
-import SimulatedEffect exposing (SimulatedEffect)
+import ProgramTest exposing (SimulatedEffect)
+import SimulatedEffect
 
 
 {-| Change the URL, but do not trigger a page load.

--- a/src/SimulatedEffect/Ports.elm
+++ b/src/SimulatedEffect/Ports.elm
@@ -15,7 +15,8 @@ For a detailed example, see the [“Testing programs with ports” guidebook](ht
 
 import Json.Decode
 import Json.Encode
-import SimulatedEffect exposing (SimulatedEffect, SimulatedSub)
+import ProgramTest exposing (SimulatedEffect, SimulatedSub)
+import SimulatedEffect
 
 
 {-| Creates a `SimulatedEffect` that parallels using an outgoing Elm port.

--- a/src/SimulatedEffect/Process.elm
+++ b/src/SimulatedEffect/Process.elm
@@ -13,7 +13,8 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 
 -}
 
-import SimulatedEffect exposing (SimulatedTask)
+import ProgramTest exposing (SimulatedTask)
+import SimulatedEffect
 
 
 {-| Block progress on the current process for the given number of milliseconds.

--- a/src/SimulatedEffect/Sub.elm
+++ b/src/SimulatedEffect/Sub.elm
@@ -15,7 +15,8 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 -}
 
 import Json.Decode
-import SimulatedEffect exposing (SimulatedEffect, SimulatedSub)
+import ProgramTest exposing (SimulatedEffect, SimulatedSub)
+import SimulatedEffect
 
 
 {-| Tell the runtime that there are no subscriptions.

--- a/src/SimulatedEffect/Task.elm
+++ b/src/SimulatedEffect/Task.elm
@@ -34,7 +34,8 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 
 -}
 
-import SimulatedEffect exposing (SimulatedEffect, SimulatedTask)
+import ProgramTest exposing (SimulatedEffect, SimulatedTask)
+import SimulatedEffect
 
 
 {-| -}

--- a/src/Test/Http.elm
+++ b/src/Test/Http.elm
@@ -1,5 +1,5 @@
 module Test.Http exposing
-    ( expectJsonBody, hasHeader
+    ( expectJsonBody, HttpRequest, hasHeader
     , timeout, networkError, httpResponse
     )
 
@@ -11,7 +11,7 @@ _Pull requests are welcome to add more useful functions._
 
 These functions provide some convenient checks that can be used with [`ProgramTest.expectHttpRequest`](ProgramTest#expectHttpRequest).
 
-@docs expectJsonBody, hasHeader
+@docs expectJsonBody, HttpRequest, hasHeader
 
 
 ## Responses
@@ -26,7 +26,17 @@ import Dict exposing (Dict)
 import Expect exposing (Expectation)
 import Http
 import Json.Decode
-import SimulatedEffect
+import SimulatedEffect exposing (SimulatedTask)
+
+
+{-| -}
+type alias HttpRequest x a =
+    { method : String
+    , url : String
+    , body : String
+    , headers : List ( String, String )
+    , onRequestComplete : Http.Response String -> SimulatedTask x a
+    }
 
 
 {-| A convenient way to check something about the request body of a pending HTTP request.
@@ -43,7 +53,7 @@ import SimulatedEffect
 expectJsonBody :
     Json.Decode.Decoder requestBody
     -> (requestBody -> Expectation)
-    -> SimulatedEffect.HttpRequest x a
+    -> HttpRequest x a
     -> Expectation
 expectJsonBody decoder check request =
     case Json.Decode.decodeString decoder request.body of
@@ -62,7 +72,7 @@ expectJsonBody decoder check request =
             (Test.Http.hasHeader "Content-Type" "application/json")
 
 -}
-hasHeader : String -> String -> SimulatedEffect.HttpRequest x a -> Expectation
+hasHeader : String -> String -> HttpRequest x a -> Expectation
 hasHeader key value { headers } =
     let
         key_ =


### PR DESCRIPTION
- [x] ran tests locally with `npm test`
- [x] updated CHANGELOG.md if appropriate
- [x] ran CI with `./ci/run-in-docker.sh https://github.com/<your username>/elm-program-test.git <your branch>`

Fixes #128 