### PR TITLE
clickButton can now click buttons containing only an image with alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New features:
   - Added `expectHttpRequests` for checking whether multiple requests have been made to the same endpoint (or that zero requests have been made).
   - Added `simulateHttpResponseAdvanced` for simulating HTTP responses when multiple requests have been made to the same endpoint.
   - Added `SimulatedEffect.Time.now`
+  - `clickButton` can now click buttons containing only an image with alt text
 
 
 ## 3.5.1

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -838,6 +838,18 @@ clickButton buttonText programTest =
                     )
                     Test.Html.Event.click
               )
+            , ( "<button> (not disabled) with onClick containing an <img> with alt=" ++ String.Extra.escape buttonText
+              , simulateHelper functionDescription
+                    (findNotDisabled
+                        [ Selector.tag "button"
+                        , Selector.containing
+                            [ Selector.tag "img"
+                            , Selector.attribute (Html.Attributes.alt buttonText)
+                            ]
+                        ]
+                    )
+                    Test.Html.Event.click
+              )
             , ( "<button> (not disabled) with onClick and attribute aria-label=" ++ String.Extra.escape buttonText
               , simulateHelper functionDescription
                     (findNotDisabled

--- a/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
@@ -22,6 +22,20 @@ all =
                     )
                     |> ProgramTest.clickButton "Click Me"
                     |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
+        , test "can click a button containing an image with alt text" <|
+            \() ->
+                TestingProgram.startView
+                    (Html.button
+                        [ onClick (Log "CLICK") ]
+                        [ Html.img
+                            [ Html.Attributes.src "googoo.png"
+                            , Html.Attributes.alt "Click Me"
+                            ]
+                            []
+                        ]
+                    )
+                    |> ProgramTest.clickButton "Click Me"
+                    |> ProgramTest.expectModel (Expect.equal [ "CLICK" ])
         , test "can click a button with an aria-label attribute" <|
             \() ->
                 TestingProgram.startView
@@ -129,6 +143,7 @@ all =
                         , ""
                         , "Expected one of the following to exist:"
                         , "- <button> (not disabled) with onClick and text \"Click Me\""
+                        , "- <button> (not disabled) with onClick containing an <img> with alt=\"Click Me\""
                         , "- <button> (not disabled) with onClick and attribute aria-label=\"Click Me\""
                         , "- an element with role=\"button\" (not disabled) and onClick and text \"Click Me\""
                         , "- an element with role=\"button\" (not disabled) and onClick and aria-label=\"Click Me\""


### PR DESCRIPTION
Fixes https://github.com/avh4/elm-program-test/issues/108

- [x] ran tests locally with `npm test`
- [x] updated CHANGELOG.md if appropriate
- [x] ran CI with `./ci/run-in-docker.sh https://github.com/<your username>/elm-program-test.git <your branch>`
