### PR TITLE
Using `ensureViewHasNot` inside of `within` no longer passes when `wi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ New features:
     - All passing steps of a query up to the failure will be displayed
   - Failure messages simplify the HTML to show only what's relevant to the failure
 
+Bug fixes:
+
+  - Using `ensureViewHasNot` inside of `within` no longer passes when `within` fails to find its target.
+
+
 ## 3.6.1
 
 New features:

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -1312,28 +1312,30 @@ then the following will allow you to simulate clicking the "Submit" button in th
 -}
 within : (Query.Single msg -> Query.Single msg) -> (ProgramTest model msg effect -> ProgramTest model msg effect) -> (ProgramTest model msg effect -> ProgramTest model msg effect)
 within findTarget onScopedTest =
-    andThen <|
-        \program state ->
-            case
-                Created
-                    { state = Ok state
-                    , program =
-                        { program
-                            | withinFocus = program.withinFocus >> findTarget
-                        }
-                    }
-                    |> onScopedTest
-            of
-                Created created ->
-                    case created.state of
-                        Ok s ->
-                            Ok s
+    andThen (expectViewHelper "within" (findTarget >> Query.has []))
+        >> (andThen <|
+                \program state ->
+                    case
+                        Created
+                            { state = Ok state
+                            , program =
+                                { program
+                                    | withinFocus = program.withinFocus >> findTarget
+                                }
+                            }
+                            |> onScopedTest
+                    of
+                        Created created ->
+                            case created.state of
+                                Ok s ->
+                                    Ok s
 
-                        Err e ->
-                            Err e.reason
+                                Err e ->
+                                    Err e.reason
 
-                FailedToCreate failure ->
-                    Err failure
+                        FailedToCreate failure ->
+                            Err failure
+           )
 
 
 {-| Asserts that an HTTP request to the specific url and method has been made.

--- a/src/ProgramTest/ComplexQuery.elm
+++ b/src/ProgramTest/ComplexQuery.elm
@@ -287,39 +287,19 @@ simulate event prev =
 
         QueryResult state prevHighlight prevContext (Ok source) ->
             case
-                -- This check is maybe not needed anymore since the previous finds should all short circuit their errors?
                 source
-                    |> Query.has []
-                    |> Test.Runner.getFailureReason
+                    |> Test.Html.Event.simulate event
+                    |> Test.Html.Event.toResult
             of
-                Just reason ->
+                Err message ->
                     QueryResult
                         state
                         prevHighlight
-                        prevContext
-                        --(Err (QueryFailed (TestHtmlHacks.parseFailureReason reason.description)))
-                        (Err (QueryFailed (TestHtmlHacks.parseFailureReason "XXX: Does this code ever run????")))
+                        (Description (Err ("simulate " ++ Tuple.first event)) :: prevContext)
+                        (Err (SimulateFailed (TestHtmlHacks.parseSimulateFailure message)))
 
-                Nothing ->
-                    -- Try to simulate the event, now that we know the target exists
-                    case
-                        source
-                            |> Test.Html.Event.simulate event
-                            |> Test.Html.Event.toResult
-                    of
-                        Err message ->
-                            QueryResult
-                                state
-                                prevHighlight
-                                (Description (Err ("simulate " ++ Tuple.first event)) :: prevContext)
-                                (Err (SimulateFailed (TestHtmlHacks.parseSimulateFailure message)))
-
-                        Ok msg ->
-                            QueryResult
-                                state
-                                prevHighlight
-                                prevContext
-                                (Ok msg)
+                Ok msg ->
+                    QueryResult state prevHighlight prevContext (Ok msg)
 
 
 {-| Ensure that the given query succeeds, but then ignore its result.

--- a/tests/ProgramTestTests.elm
+++ b/tests/ProgramTestTests.elm
@@ -264,6 +264,71 @@ all =
                         (ProgramTest.clickButton "Ambiguous click")
                     |> ProgramTest.clickButton "Click Me"
                     |> ProgramTest.expectModel (Expect.equal "INIT;CLICK-B;CLICK")
+        , test "a failing within fails when containing assertViewHasNot" <|
+            \() ->
+                start
+                    |> ProgramTest.within
+                        (Query.findAll [ Selector.tag "not-there" ]
+                            >> Query.first
+                        )
+                        (ProgramTest.ensureViewHasNot [ Selector.text "NOT THERE" ])
+                    |> ProgramTest.done
+                    |> expectFailure
+                        [ """within:"""
+                        , """▼ Query.fromHtml"""
+                        , """"""
+                        , """    <div>"""
+                        , """        <span>"""
+                        , """            INIT"""
+                        , """        </span>"""
+                        , """        <button>"""
+                        , """            Click Me"""
+                        , """        </button>"""
+                        , """        <strange>"""
+                        , """        </strange>"""
+                        , """        <textarea>"""
+                        , """        </textarea>"""
+                        , """        <div>"""
+                        , """            <label htmlFor="field-1">"""
+                        , """                Field 1"""
+                        , """            </label>"""
+                        , """            <input id="field-1">"""
+                        , """            <label htmlFor="field-2">"""
+                        , """                Field 2"""
+                        , """            </label>"""
+                        , """            <input id="field-2">"""
+                        , """            <label htmlFor="checkbox-1">"""
+                        , """                Checkbox 1"""
+                        , """            </label>"""
+                        , """            <input id="checkbox-1" type="checkbox">"""
+                        , """        </div>"""
+                        , """        <div>"""
+                        , """            <div id="button-a">"""
+                        , """                <button>"""
+                        , """                    Ambiguous click"""
+                        , """                </button>"""
+                        , """            </div>"""
+                        , """            <div id="button-b">"""
+                        , """                <button>"""
+                        , """                    Ambiguous click"""
+                        , """                </button>"""
+                        , """            </div>"""
+                        , """        </div>"""
+                        , """    </div>"""
+                        , """"""
+                        , """"""
+                        , """▼ Query.findAll [ tag "not-there" ]"""
+                        , """"""
+                        , """0 matches found for this query."""
+                        , """"""
+                        , """"""
+                        , """▼ Query.first"""
+                        , """"""
+                        , """0 matches found for this query."""
+                        , """"""
+                        , """"""
+                        , """✗ Query.first always expects to find 1 element, but it found 0 instead."""
+                        ]
         , test "can simulate setting a labeled checkbox field" <|
             \() ->
                 start


### PR DESCRIPTION
- [x] ran tests locally with `npm test`
- [x] updated CHANGELOG.md if appropriate

Fixes https://github.com/avh4/elm-program-test/issues/95