### PR TITLE
Fix "bad" checks for clickButton role=button case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 Bug fixes:
 
   - Using `ensureViewHasNot` inside of `within` no longer passes when `within` fails to find its target.
+  - `clickButton` works correctly with `role=button` elements when there are other `<button>` elements in view.
 
 
 ## 3.6.1

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -855,7 +855,13 @@ clickButton buttonText =
             , ( "any element with role=\"button\" and text"
               , findNotDisabled (Just "find button")
                     [ "button" ]
-                    (Just [ Selector.tag "button" ])
+                    (Just
+                        [ Selector.all
+                            [ Selector.tag "button"
+                            , Selector.attribute (Html.Attributes.attribute "role" "button")
+                            ]
+                        ]
+                    )
                     [ Selector.attribute (Html.Attributes.attribute "role" "button")
                     , Selector.containing [ Selector.text buttonText ]
                     ]
@@ -864,7 +870,13 @@ clickButton buttonText =
             , ( "any element with role=\"button\" and aria-label"
               , findNotDisabled (Just "find button")
                     [ "button" ]
-                    (Just [ Selector.tag "button" ])
+                    (Just
+                        [ Selector.all
+                            [ Selector.tag "button"
+                            , Selector.attribute (Html.Attributes.attribute "role" "button")
+                            ]
+                        ]
+                    )
                     [ Selector.attribute (Html.Attributes.attribute "role" "button")
                     , Selector.attribute (Html.Attributes.attribute "aria-label" buttonText)
                     ]

--- a/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
@@ -236,23 +236,14 @@ all =
                         , "If that's what you intended, use `ProgramTest.within` to focus in on a portion of"
                         , "the view that contains only one of the matches."
                         ]
-        , issue144
-        ]
-
-
-issue144 : Test
-issue144 =
-    describe "regression test for #144"
-        [ test "finds role='button' span when another button is also present" <|
+        , -- https://github.com/avh4/elm-program-test/issues/149
+          test "finds role='button' span when another button is also present" <|
             \() ->
                 TestingProgram.startView
                     (Html.span []
                         [ Html.span
-                            [ -- not including tabindex or other necessary attributes for test simplicity
-                              Html.Attributes.attribute "role" "button"
+                            [ Html.Attributes.attribute "role" "button"
                             , Html.Events.onClick (Log "CLICK")
-
-                            -- Comment the following line in order to get a slighlty different failure:
                             , Html.Attributes.disabled False
                             ]
                             [ Html.map never (Html.text "Clickable element") ]

--- a/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickButtonTest.elm
@@ -236,4 +236,29 @@ all =
                         , "If that's what you intended, use `ProgramTest.within` to focus in on a portion of"
                         , "the view that contains only one of the matches."
                         ]
+        , issue144
+        ]
+
+
+issue144 : Test
+issue144 =
+    describe "regression test for #144"
+        [ test "finds role='button' span when another button is also present" <|
+            \() ->
+                TestingProgram.startView
+                    (Html.span []
+                        [ Html.span
+                            [ -- not including tabindex or other necessary attributes for test simplicity
+                              Html.Attributes.attribute "role" "button"
+                            , Html.Events.onClick (Log "CLICK")
+
+                            -- Comment the following line in order to get a slighlty different failure:
+                            , Html.Attributes.disabled False
+                            ]
+                            [ Html.map never (Html.text "Clickable element") ]
+                        , Html.button [] [ Html.text "Panda" ]
+                        ]
+                    )
+                    |> ProgramTest.clickButton "Clickable element"
+                    |> ProgramTest.done
         ]


### PR DESCRIPTION
- [x] ran tests locally with `npm test`
- [x] updated CHANGELOG.md if appropriate

Fixes https://github.com/avh4/elm-program-test/issues/149

The "role=button" cases tried to filter out matching `<button role="button">` because that's redundant with the `<button>` cases.  The new query type apparently fixed a bug in the querying that made this incorrect check actually start failing.  Making the filter more precise seems to solve it.