### PR TITLE
Change function name in doc

### DIFF
--- a/docs/ports.md
+++ b/docs/ports.md
@@ -136,7 +136,7 @@ start =
         , view = Main.view
         }
         |> ProgramTest.withSimulatedEffects simulateEffects
-        |> ProgramTest.withSimulatedSubscriptions simulateSub
+        |> ProgramTest.withSimulatedSubscriptions simulateSubscriptions
         |> ProgramTest.start ()
 ```
 


### PR DESCRIPTION
Hello, I found a tiny inconsistency in the docs, and created a PR for it.

The helper function is called `simulateSubscriptions` and not `simulateSub`, and the description text above the code snippet also uses that name.

So I changed the name in the code snippet.
