### PR TITLE
Fix click link for applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,104 +1,101 @@
+## 3.6.4
+
+Bug fixes:
+
+- `clickLink` now works for internal links when testing a `Browser.application`
+- `pushUrl` now works for relative urls with query and/or fragment
+
 ## 3.6.3
 
 Bug fixes:
 
-  - Performance regression in 3.6.2 for passing tests is fixed.
-
+- Performance regression in 3.6.2 for passing tests is fixed.
 
 ## 3.6.2
 
 New features:
 
-  - Functions to simulate DOM events display errors more nicely:
-    - Extra junk like "`✗ has text "HTML expected by the call to: ..."`" has been removed
-    - All passing steps of a query up to the failure will be displayed
-  - Failure messages simplify the HTML to show only what's relevant to the failure
+- Functions to simulate DOM events display errors more nicely:
+  - Extra junk like "`✗ has text "HTML expected by the call to: ..."`" has been removed
+  - All passing steps of a query up to the failure will be displayed
+- Failure messages simplify the HTML to show only what's relevant to the failure
 
 Bug fixes:
 
-  - Using `ensureViewHasNot` inside of `within` no longer passes when `within` fails to find its target.
-  - `clickButton` works correctly with `role=button` elements when there are other `<button>` elements in view.
-
+- Using `ensureViewHasNot` inside of `within` no longer passes when `within` fails to find its target.
+- `clickButton` works correctly with `role=button` elements when there are other `<button>` elements in view.
 
 ## 3.6.1
 
 New features:
 
-  - Functions to simulate DOM events now report more detailed and more relevant information in the case of failure.
+- Functions to simulate DOM events now report more detailed and more relevant information in the case of failure.
 
 Bug fixes:
 
-  - Functions to simulate DOM events now correctly fail in all cases when there are multiple possible matches.
-
+- Functions to simulate DOM events now correctly fail in all cases when there are multiple possible matches.
 
 ## 3.6.0
 
 Changes:
 
-  - `expectHttpRequestWasMade`, `expectHttpRequest`, and `simulateHttpResponse` will now fail if multiple pending requests have been made to the relevant (method, URL) pair.
+- `expectHttpRequestWasMade`, `expectHttpRequest`, and `simulateHttpResponse` will now fail if multiple pending requests have been made to the relevant (method, URL) pair.
 
 New features:
 
-  - Added `expectHttpRequests` for checking whether multiple requests have been made to the same endpoint (or that zero requests have been made).
-  - Added `simulateHttpResponseAdvanced` for simulating HTTP responses when multiple requests have been made to the same endpoint.
-  - Added `SimulatedEffect.Time.now`
-  - `clickButton` can now click buttons containing only an image with alt text
-
+- Added `expectHttpRequests` for checking whether multiple requests have been made to the same endpoint (or that zero requests have been made).
+- Added `simulateHttpResponseAdvanced` for simulating HTTP responses when multiple requests have been made to the same endpoint.
+- Added `SimulatedEffect.Time.now`
+- `clickButton` can now click buttons containing only an image with alt text
 
 ## 3.5.1
 
 Bug fixes:
 
-  - Resolving a relative URL (such as when `clickLink` is used) is correct in more cases (specifically, when the base URL has a query or fragment string)
-
+- Resolving a relative URL (such as when `clickLink` is used) is correct in more cases (specifically, when the base URL has a query or fragment string)
 
 ## 3.5.0
 
 Packaging:
 
-  - The `HttpRequest` type is now exposed.
-
+- The `HttpRequest` type is now exposed.
 
 ## 3.4.0
 
 New features:
 
-  - Added to `SimulatedEffect.Task`: `map2`, `map3`, `map4`, `map5`, `onError`
+- Added to `SimulatedEffect.Task`: `map2`, `map3`, `map4`, `map5`, `onError`
 
 Documentation:
 
-  - Added [NavigationKeyExample](https://github.com/avh4/elm-program-test/blob/main/examples/tests/NavigationKeyExampleTest.elm) showing how to test programs that require the use of `Browser.Navigation.Key`
-
+- Added [NavigationKeyExample](https://github.com/avh4/elm-program-test/blob/main/examples/tests/NavigationKeyExampleTest.elm) showing how to test programs that require the use of `Browser.Navigation.Key`
 
 ## 3.3.0
 
 New features:
 
-  - `clickButton` can now match `<button>` and `role=button` elements via their `aria-label`
-  - added API for simulating browser navigation in `SimulatedEffect.Navigation`: `back`, `load`, `reload`, `reloadAndSkipCache`
-  - added `ProgramTest.getOutgoingPortValues` for use in advanced helper functions
-
+- `clickButton` can now match `<button>` and `role=button` elements via their `aria-label`
+- added API for simulating browser navigation in `SimulatedEffect.Navigation`: `back`, `load`, `reload`, `reloadAndSkipCache`
+- added `ProgramTest.getOutgoingPortValues` for use in advanced helper functions
 
 ## 3.2.0
 
 New features:
 
-  - added `ProgramTest.expectBrowserUrl`
-  - added `ProgramTest.expectBrowserHistory`
-  - `clickButton` on a submit button in a form will now trigger the onSubmit of the form
+- added `ProgramTest.expectBrowserUrl`
+- added `ProgramTest.expectBrowserHistory`
+- `clickButton` on a submit button in a form will now trigger the onSubmit of the form
 
 Bug fixes:
 
-  - `fillIn` will now work when the target input has both an `aria-label` and an `id`
-
+- `fillIn` will now work when the target input has both an `aria-label` and an `id`
 
 ## 3.1.0
 
 New features:
 
-  - added `SimulatedEffect.Http.expectStringResponse`
-  - added `ProgramTest.createWorker`
-
+- added `SimulatedEffect.Http.expectStringResponse`
+- added `ProgramTest.createWorker`
 
 ## 3.0.0
 
@@ -107,73 +104,65 @@ See [Upgrading elm-program-test 2.x to 3.x](https://elm-program-test.netlify.com
 
 API Changes:
 
-  - The core module is renamed from `TestContext` -> `ProgramTest`
-  - Redesigned API for creating and starting tests
-  - Many assertion functions are renamed so that the API is more consistent
-  
+- The core module is renamed from `TestContext` -> `ProgramTest`
+- Redesigned API for creating and starting tests
+- Many assertion functions are renamed so that the API is more consistent
+
 New features:
- 
-  - support for testing HTTP requests (see `expectHttpRequestWasMade` and `simulateHttpOk`)
-  - support for testing ports (see `expectOutgoingPortValues` and `simulateIncomingPort`)
-  - support for testing `Task.sleep` (see `advanceTime`)
-  
+
+- support for testing HTTP requests (see `expectHttpRequestWasMade` and `simulateHttpOk`)
+- support for testing ports (see `expectOutgoingPortValues` and `simulateIncomingPort`)
+- support for testing `Task.sleep` (see `advanceTime`)
+
 New documentation:
 
-  - new guidebook: [Testing programs with interactive views](https://elm-program-test.netlify.com/html.html)
-  - new guidebook: [Testing programs with Cmds](https://elm-program-test.netlify.com/cmds.html)
-  - new guidebook: [Testing programs with ports](https://elm-program-test.netlify.com/cmds.html)
-
+- new guidebook: [Testing programs with interactive views](https://elm-program-test.netlify.com/html.html)
+- new guidebook: [Testing programs with Cmds](https://elm-program-test.netlify.com/cmds.html)
+- new guidebook: [Testing programs with ports](https://elm-program-test.netlify.com/cmds.html)
 
 ## 2.3.2
 
-  - dependency on `elm/json` is relaxed to `1.0.0 <= v < 2.0.0` 
-
+- dependency on `elm/json` is relaxed to `1.0.0 <= v < 2.0.0`
 
 ## 2.3.1
 
 New features:
 
-  - `clickButton` now works with non-`<button>` elements having `role="button"`
-  - `clickButton` now fails if the button is disabled
-
+- `clickButton` now works with non-`<button>` elements having `role="button"`
+- `clickButton` now fails if the button is disabled
 
 ## 2.3.0
 
 New features:
 
-  - `fillIn` now works with id-less `<input>` tags that are descendants of their `<label>`
-  - `fillIn` now works with `aria-label` attributes
-  - added `createFailed` for use in writing helper functions that create `TestContext`s
-
+- `fillIn` now works with id-less `<input>` tags that are descendants of their `<label>`
+- `fillIn` now works with `aria-label` attributes
+- added `createFailed` for use in writing helper functions that create `TestContext`s
 
 ## 2.2.0
 
 New features:
 
-  - functions to simulate select/option input: `selectOption`
-
+- functions to simulate select/option input: `selectOption`
 
 ## 2.1.0
 
 New features:
 
-  - added `simulateLastEffect`
-
+- added `simulateLastEffect`
 
 ## 2.0.0
 
 Updated to support Elm 0.19.
 
-
 ## 1.1.0
 
 New features:
 
-  - functions to simulate text input: `fillIn`, `fillInTextarea`
-  - functions to simulate checkbox input: `check`
-  - functions to simulate and validated clicking links: `clickLink`, `expectPageChange`, `createWithBaseUrl`
-  - functions for custom assertions: `within`
-
+- functions to simulate text input: `fillIn`, `fillInTextarea`
+- functions to simulate checkbox input: `check`
+- functions to simulate and validated clicking links: `clickLink`, `expectPageChange`, `createWithBaseUrl`
+- functions for custom assertions: `within`
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 3.6.4
 
-Bug fixes:
+New features:
 
 - `clickLink` now works for internal links when testing a `Browser.application`
-- `pushUrl` now works for relative urls with query and/or fragment
+- `pushUrl` now works properly for relative urls with query and/or fragment
 
 
 ## 3.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,97 +5,108 @@ Bug fixes:
 - `clickLink` now works for internal links when testing a `Browser.application`
 - `pushUrl` now works for relative urls with query and/or fragment
 
+
 ## 3.6.3
 
 Bug fixes:
 
-- Performance regression in 3.6.2 for passing tests is fixed.
+  - Performance regression in 3.6.2 for passing tests is fixed.
+
 
 ## 3.6.2
 
 New features:
 
-- Functions to simulate DOM events display errors more nicely:
-  - Extra junk like "`✗ has text "HTML expected by the call to: ..."`" has been removed
-  - All passing steps of a query up to the failure will be displayed
-- Failure messages simplify the HTML to show only what's relevant to the failure
+  - Functions to simulate DOM events display errors more nicely:
+    - Extra junk like "`✗ has text "HTML expected by the call to: ..."`" has been removed
+    - All passing steps of a query up to the failure will be displayed
+  - Failure messages simplify the HTML to show only what's relevant to the failure
 
 Bug fixes:
 
-- Using `ensureViewHasNot` inside of `within` no longer passes when `within` fails to find its target.
-- `clickButton` works correctly with `role=button` elements when there are other `<button>` elements in view.
+  - Using `ensureViewHasNot` inside of `within` no longer passes when `within` fails to find its target.
+  - `clickButton` works correctly with `role=button` elements when there are other `<button>` elements in view.
+
 
 ## 3.6.1
 
 New features:
 
-- Functions to simulate DOM events now report more detailed and more relevant information in the case of failure.
+  - Functions to simulate DOM events now report more detailed and more relevant information in the case of failure.
 
 Bug fixes:
 
-- Functions to simulate DOM events now correctly fail in all cases when there are multiple possible matches.
+  - Functions to simulate DOM events now correctly fail in all cases when there are multiple possible matches.
+
 
 ## 3.6.0
 
 Changes:
 
-- `expectHttpRequestWasMade`, `expectHttpRequest`, and `simulateHttpResponse` will now fail if multiple pending requests have been made to the relevant (method, URL) pair.
+  - `expectHttpRequestWasMade`, `expectHttpRequest`, and `simulateHttpResponse` will now fail if multiple pending requests have been made to the relevant (method, URL) pair.
 
 New features:
 
-- Added `expectHttpRequests` for checking whether multiple requests have been made to the same endpoint (or that zero requests have been made).
-- Added `simulateHttpResponseAdvanced` for simulating HTTP responses when multiple requests have been made to the same endpoint.
-- Added `SimulatedEffect.Time.now`
-- `clickButton` can now click buttons containing only an image with alt text
+  - Added `expectHttpRequests` for checking whether multiple requests have been made to the same endpoint (or that zero requests have been made).
+  - Added `simulateHttpResponseAdvanced` for simulating HTTP responses when multiple requests have been made to the same endpoint.
+  - Added `SimulatedEffect.Time.now`
+  - `clickButton` can now click buttons containing only an image with alt text
+
 
 ## 3.5.1
 
 Bug fixes:
 
-- Resolving a relative URL (such as when `clickLink` is used) is correct in more cases (specifically, when the base URL has a query or fragment string)
+  - Resolving a relative URL (such as when `clickLink` is used) is correct in more cases (specifically, when the base URL has a query or fragment string)
+
 
 ## 3.5.0
 
 Packaging:
 
-- The `HttpRequest` type is now exposed.
+  - The `HttpRequest` type is now exposed.
+
 
 ## 3.4.0
 
 New features:
 
-- Added to `SimulatedEffect.Task`: `map2`, `map3`, `map4`, `map5`, `onError`
+  - Added to `SimulatedEffect.Task`: `map2`, `map3`, `map4`, `map5`, `onError`
 
 Documentation:
 
-- Added [NavigationKeyExample](https://github.com/avh4/elm-program-test/blob/main/examples/tests/NavigationKeyExampleTest.elm) showing how to test programs that require the use of `Browser.Navigation.Key`
+  - Added [NavigationKeyExample](https://github.com/avh4/elm-program-test/blob/main/examples/tests/NavigationKeyExampleTest.elm) showing how to test programs that require the use of `Browser.Navigation.Key`
+
 
 ## 3.3.0
 
 New features:
 
-- `clickButton` can now match `<button>` and `role=button` elements via their `aria-label`
-- added API for simulating browser navigation in `SimulatedEffect.Navigation`: `back`, `load`, `reload`, `reloadAndSkipCache`
-- added `ProgramTest.getOutgoingPortValues` for use in advanced helper functions
+  - `clickButton` can now match `<button>` and `role=button` elements via their `aria-label`
+  - added API for simulating browser navigation in `SimulatedEffect.Navigation`: `back`, `load`, `reload`, `reloadAndSkipCache`
+  - added `ProgramTest.getOutgoingPortValues` for use in advanced helper functions
+
 
 ## 3.2.0
 
 New features:
 
-- added `ProgramTest.expectBrowserUrl`
-- added `ProgramTest.expectBrowserHistory`
-- `clickButton` on a submit button in a form will now trigger the onSubmit of the form
+  - added `ProgramTest.expectBrowserUrl`
+  - added `ProgramTest.expectBrowserHistory`
+  - `clickButton` on a submit button in a form will now trigger the onSubmit of the form
 
 Bug fixes:
 
-- `fillIn` will now work when the target input has both an `aria-label` and an `id`
+  - `fillIn` will now work when the target input has both an `aria-label` and an `id`
+
 
 ## 3.1.0
 
 New features:
 
-- added `SimulatedEffect.Http.expectStringResponse`
-- added `ProgramTest.createWorker`
+  - added `SimulatedEffect.Http.expectStringResponse`
+  - added `ProgramTest.createWorker`
+
 
 ## 3.0.0
 
@@ -104,65 +115,73 @@ See [Upgrading elm-program-test 2.x to 3.x](https://elm-program-test.netlify.com
 
 API Changes:
 
-- The core module is renamed from `TestContext` -> `ProgramTest`
-- Redesigned API for creating and starting tests
-- Many assertion functions are renamed so that the API is more consistent
-
+  - The core module is renamed from `TestContext` -> `ProgramTest`
+  - Redesigned API for creating and starting tests
+  - Many assertion functions are renamed so that the API is more consistent
+  
 New features:
-
-- support for testing HTTP requests (see `expectHttpRequestWasMade` and `simulateHttpOk`)
-- support for testing ports (see `expectOutgoingPortValues` and `simulateIncomingPort`)
-- support for testing `Task.sleep` (see `advanceTime`)
-
+ 
+  - support for testing HTTP requests (see `expectHttpRequestWasMade` and `simulateHttpOk`)
+  - support for testing ports (see `expectOutgoingPortValues` and `simulateIncomingPort`)
+  - support for testing `Task.sleep` (see `advanceTime`)
+  
 New documentation:
 
-- new guidebook: [Testing programs with interactive views](https://elm-program-test.netlify.com/html.html)
-- new guidebook: [Testing programs with Cmds](https://elm-program-test.netlify.com/cmds.html)
-- new guidebook: [Testing programs with ports](https://elm-program-test.netlify.com/cmds.html)
+  - new guidebook: [Testing programs with interactive views](https://elm-program-test.netlify.com/html.html)
+  - new guidebook: [Testing programs with Cmds](https://elm-program-test.netlify.com/cmds.html)
+  - new guidebook: [Testing programs with ports](https://elm-program-test.netlify.com/cmds.html)
+
 
 ## 2.3.2
 
-- dependency on `elm/json` is relaxed to `1.0.0 <= v < 2.0.0`
+  - dependency on `elm/json` is relaxed to `1.0.0 <= v < 2.0.0` 
+
 
 ## 2.3.1
 
 New features:
 
-- `clickButton` now works with non-`<button>` elements having `role="button"`
-- `clickButton` now fails if the button is disabled
+  - `clickButton` now works with non-`<button>` elements having `role="button"`
+  - `clickButton` now fails if the button is disabled
+
 
 ## 2.3.0
 
 New features:
 
-- `fillIn` now works with id-less `<input>` tags that are descendants of their `<label>`
-- `fillIn` now works with `aria-label` attributes
-- added `createFailed` for use in writing helper functions that create `TestContext`s
+  - `fillIn` now works with id-less `<input>` tags that are descendants of their `<label>`
+  - `fillIn` now works with `aria-label` attributes
+  - added `createFailed` for use in writing helper functions that create `TestContext`s
+
 
 ## 2.2.0
 
 New features:
 
-- functions to simulate select/option input: `selectOption`
+  - functions to simulate select/option input: `selectOption`
+
 
 ## 2.1.0
 
 New features:
 
-- added `simulateLastEffect`
+  - added `simulateLastEffect`
+
 
 ## 2.0.0
 
 Updated to support Elm 0.19.
 
+
 ## 1.1.0
 
 New features:
 
-- functions to simulate text input: `fillIn`, `fillInTextarea`
-- functions to simulate checkbox input: `check`
-- functions to simulate and validated clicking links: `clickLink`, `expectPageChange`, `createWithBaseUrl`
-- functions for custom assertions: `within`
+  - functions to simulate text input: `fillIn`, `fillInTextarea`
+  - functions to simulate checkbox input: `check`
+  - functions to simulate and validated clicking links: `clickLink`, `expectPageChange`, `createWithBaseUrl`
+  - functions for custom assertions: `within`
+
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 (including `Test.Html`)
 for testing your Elm programs as complete units.
 
-## How to install
+## How to install 
 
 1. Install the [elm-explorations/test](https://package.elm-lang.org/packages/elm-explorations/test/latest/).
 2. Install the elm-program-test using the command
 
-   `elm-test install avh4/elm-program-test`
+    ```elm-test install avh4/elm-program-test```
+
 
 ## [Guidebooks](https://elm-program-test.netlify.com/#guidebooks)
 
@@ -29,6 +30,7 @@ For more detailed documentation, the following guides show examples of how to us
 - [Testing programs with ports](https://elm-program-test.netlify.com/ports.html) &mdash; shows testing a program
   that uses ports to interface with JavaScript
 - [Upgrading from elm-program-test 2.x to 3.x](https://elm-program-test.netlify.com/upgrade-3.0.0.html)
+
 
 ## Basic example
 
@@ -61,6 +63,7 @@ exampleProgramTest =
                     ]
 ```
 
+
 ## Testing programs with flags and/or navigation
 
 This example tests a program that requires both [flags](https://guide.elm-lang.org/interop/flags.html) and [navigation](https://package.elm-lang.org/packages/elm/browser/latest/Browser#application).
@@ -76,7 +79,8 @@ import MyProgram exposing (Flags, Msg, Model) -- just an imaginary example
 start : String -> Flags -> ProgramTest Model Msg (Cmd Msg)
 start initialUrl flags =
     ProgramTest.createApplication
-        { onUrlChange = MyProgram.onUrlChange
+        { onUrlChange = MyProgram.OnUrlChange
+        , onUrlRequest = MyProgram.OnUrlRequest
         , init =
             -- NOTE: the type of MyProgram.init is:
             -- MyProgram.Flags -> Navigation.Location -> (MyProgram.Model, Cmd MyProgram.Msg)
@@ -98,6 +102,7 @@ exampleProgramTest =
                     , attribute (href "https://super.social.example.com/avh4")
                     ]
 ```
+
 
 ## Testing view modules (not full programs)
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@
 (including `Test.Html`)
 for testing your Elm programs as complete units.
 
-## How to install 
+## How to install
 
 1. Install the [elm-explorations/test](https://package.elm-lang.org/packages/elm-explorations/test/latest/).
 2. Install the elm-program-test using the command
 
-    ```elm-test install avh4/elm-program-test```
-
+   `elm-test install avh4/elm-program-test`
 
 ## [Guidebooks](https://elm-program-test.netlify.com/#guidebooks)
 
@@ -30,7 +29,6 @@ For more detailed documentation, the following guides show examples of how to us
 - [Testing programs with ports](https://elm-program-test.netlify.com/ports.html) &mdash; shows testing a program
   that uses ports to interface with JavaScript
 - [Upgrading from elm-program-test 2.x to 3.x](https://elm-program-test.netlify.com/upgrade-3.0.0.html)
-
 
 ## Basic example
 
@@ -63,7 +61,6 @@ exampleProgramTest =
                     ]
 ```
 
-
 ## Testing programs with flags and/or navigation
 
 This example tests a program that requires both [flags](https://guide.elm-lang.org/interop/flags.html) and [navigation](https://package.elm-lang.org/packages/elm/browser/latest/Browser#application).
@@ -79,7 +76,7 @@ import MyProgram exposing (Flags, Msg, Model) -- just an imaginary example
 start : String -> Flags -> ProgramTest Model Msg (Cmd Msg)
 start initialUrl flags =
     ProgramTest.createApplication
-        { onUrlChange = MyProgram.OnRouteChange
+        { onUrlChange = MyProgram.onUrlChange
         , init =
             -- NOTE: the type of MyProgram.init is:
             -- MyProgram.Flags -> Navigation.Location -> (MyProgram.Model, Cmd MyProgram.Msg)
@@ -101,7 +98,6 @@ exampleProgramTest =
                     , attribute (href "https://super.social.example.com/avh4")
                     ]
 ```
-
 
 ## Testing view modules (not full programs)
 

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -303,7 +303,8 @@ createHelper :
     { init : ( model, effect )
     , update : msg -> model -> ( model, effect )
     , view : model -> Html msg
-    , onRouteChange : Url -> Maybe msg
+    , onUrlRequest : Browser.UrlRequest -> Maybe msg
+    , onUrlChange : Url -> Maybe msg
     }
     -> ProgramOptions model msg effect
     -> ProgramTest model msg effect
@@ -312,7 +313,8 @@ createHelper program options =
         program_ =
             { update = program.update
             , view = program.view
-            , onRouteChange = program.onRouteChange
+            , onUrlRequest = program.onUrlRequest
+            , onUrlChange = program.onUrlChange
             , subscriptions = options.subscriptions
             , withinFocus = identity
             }
@@ -365,7 +367,8 @@ createSandbox program =
                 { init = ( program.init, () )
                 , update = \msg model -> ( program.update msg model, () )
                 , view = program.view
-                , onRouteChange = \_ -> Nothing
+                , onUrlRequest = \_ -> Nothing
+                , onUrlChange = \_ -> Nothing
                 }
 
 
@@ -388,7 +391,8 @@ createWorker program =
                 { init = program.init flags
                 , update = program.update
                 , view = \_ -> Html.text "** Programs created with ProgramTest.createWorker do not have a view.  Use ProgramTest.createElement instead if you meant to provide a view function. **"
-                , onRouteChange = \_ -> Nothing
+                , onUrlRequest = \_ -> Nothing
+                , onUrlChange = \_ -> Nothing
                 }
 
 
@@ -412,7 +416,8 @@ createElement program =
                 { init = program.init flags
                 , update = program.update
                 , view = program.view
-                , onRouteChange = \_ -> Nothing
+                , onUrlRequest = \_ -> Nothing
+                , onUrlChange = \_ -> Nothing
                 }
 
 
@@ -530,7 +535,8 @@ createDocument program =
                 { init = program.init flags
                 , update = program.update
                 , view = \model -> Html.node "body" [] (program.view model).body
-                , onRouteChange = \_ -> Nothing
+                , onUrlRequest = \_ -> Nothing
+                , onUrlChange = \_ -> Nothing
                 }
 
 
@@ -567,7 +573,8 @@ createApplication program =
                         { init = program.init flags url ()
                         , update = program.update
                         , view = \model -> Html.node "body" [] (program.view model).body
-                        , onRouteChange = program.onUrlChange >> Just
+                        , onUrlRequest = program.onUrlRequest >> Just
+                        , onUrlChange = program.onUrlChange >> Just
                         }
 
 
@@ -1088,7 +1095,7 @@ clickLink linkText href programTest =
     programTest
         |> assertComplexQuery functionDescription
             (ComplexQuery.find Nothing [ "a" ] findLinkTag)
-        |> tryClicking { otherwise = \_ -> TestState.simulateLoadUrlHelper functionDescription href >> Err }
+        |> tryClicking { otherwise = TestState.urlRequestHelper functionDescription href }
 
 
 {-| Simulates replacing the text in an input field labeled with the given label.
@@ -1865,7 +1872,7 @@ The parameter may be an absolute URL or relative URL.
 -}
 routeChange : String -> ProgramTest model msg effect -> ProgramTest model msg effect
 routeChange url =
-    andThen (TestState.routeChangeHelper "routeChange" 0 url)
+    andThen (TestState.urlChangeHelper "routeChange" 0 url)
 
 
 {-| Make an assertion about the current state of a `ProgramTest`'s model.

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -303,8 +303,8 @@ createHelper :
     { init : ( model, effect )
     , update : msg -> model -> ( model, effect )
     , view : model -> Html msg
-    , onUrlRequest : Browser.UrlRequest -> Maybe msg
-    , onUrlChange : Url -> Maybe msg
+    , onUrlRequest : Maybe (Browser.UrlRequest -> msg)
+    , onUrlChange : Maybe (Url -> msg)
     }
     -> ProgramOptions model msg effect
     -> ProgramTest model msg effect
@@ -367,8 +367,8 @@ createSandbox program =
                 { init = ( program.init, () )
                 , update = \msg model -> ( program.update msg model, () )
                 , view = program.view
-                , onUrlRequest = \_ -> Nothing
-                , onUrlChange = \_ -> Nothing
+                , onUrlRequest = Nothing
+                , onUrlChange = Nothing
                 }
 
 
@@ -391,8 +391,8 @@ createWorker program =
                 { init = program.init flags
                 , update = program.update
                 , view = \_ -> Html.text "** Programs created with ProgramTest.createWorker do not have a view.  Use ProgramTest.createElement instead if you meant to provide a view function. **"
-                , onUrlRequest = \_ -> Nothing
-                , onUrlChange = \_ -> Nothing
+                , onUrlRequest = Nothing
+                , onUrlChange = Nothing
                 }
 
 
@@ -416,8 +416,8 @@ createElement program =
                 { init = program.init flags
                 , update = program.update
                 , view = program.view
-                , onUrlRequest = \_ -> Nothing
-                , onUrlChange = \_ -> Nothing
+                , onUrlRequest = Nothing
+                , onUrlChange = Nothing
                 }
 
 
@@ -535,8 +535,8 @@ createDocument program =
                 { init = program.init flags
                 , update = program.update
                 , view = \model -> Html.node "body" [] (program.view model).body
-                , onUrlRequest = \_ -> Nothing
-                , onUrlChange = \_ -> Nothing
+                , onUrlRequest = Nothing
+                , onUrlChange = Nothing
                 }
 
 
@@ -573,8 +573,8 @@ createApplication program =
                         { init = program.init flags url ()
                         , update = program.update
                         , view = \model -> Html.node "body" [] (program.view model).body
-                        , onUrlRequest = program.onUrlRequest >> Just
-                        , onUrlChange = program.onUrlChange >> Just
+                        , onUrlRequest = Just program.onUrlRequest
+                        , onUrlChange = Just program.onUrlChange
                         }
 
 

--- a/src/ProgramTest/Program.elm
+++ b/src/ProgramTest/Program.elm
@@ -1,5 +1,6 @@
 module ProgramTest.Program exposing (Program, renderView)
 
+import Browser
 import Html exposing (Html)
 import Test.Html.Query as Query
 import Url exposing (Url)
@@ -15,7 +16,8 @@ Note that we also parameterize `effect` and `sub` separately because
 type alias Program model msg effect sub =
     { update : msg -> model -> ( model, effect )
     , view : model -> Html msg
-    , onRouteChange : Url -> Maybe msg
+    , onUrlRequest : Browser.UrlRequest -> Maybe msg
+    , onUrlChange : Url -> Maybe msg
     , subscriptions : Maybe (model -> sub)
     , withinFocus : Query.Single msg -> Query.Single msg
     }

--- a/src/ProgramTest/Program.elm
+++ b/src/ProgramTest/Program.elm
@@ -16,8 +16,8 @@ Note that we also parameterize `effect` and `sub` separately because
 type alias Program model msg effect sub =
     { update : msg -> model -> ( model, effect )
     , view : model -> Html msg
-    , onUrlRequest : Browser.UrlRequest -> Maybe msg
-    , onUrlChange : Url -> Maybe msg
+    , onUrlRequest : Maybe (Browser.UrlRequest -> msg)
+    , onUrlChange : Maybe (Url -> msg)
     , subscriptions : Maybe (model -> sub)
     , withinFocus : Query.Single msg -> Query.Single msg
     }

--- a/src/TestState.elm
+++ b/src/TestState.elm
@@ -148,15 +148,7 @@ urlRequestHelper : String -> String -> Program model msg effect sub -> TestState
 urlRequestHelper functionDescription href program state =
     case Maybe.map .currentLocation state.navigation of
         Just location ->
-            let
-                urlRequest url =
-                    if url.host == location.host && url.port_ == location.port_ then
-                        Browser.Internal url
-
-                    else
-                        Browser.External href
-            in
-            case program.onUrlRequest (urlRequest (Url.Extra.resolve location href)) of
+            case program.onUrlRequest (Url.Extra.toUrlRequest location href) of
                 Just msg ->
                     update msg program state
 

--- a/src/TestState.elm
+++ b/src/TestState.elm
@@ -148,9 +148,9 @@ urlRequestHelper : String -> String -> Program model msg effect sub -> TestState
 urlRequestHelper functionDescription href program state =
     case Maybe.map .currentLocation state.navigation of
         Just location ->
-            case program.onUrlRequest (Url.Extra.toUrlRequest location href) of
-                Just msg ->
-                    update msg program state
+            case program.onUrlRequest of
+                Just onUrlRequest ->
+                    update (onUrlRequest (Url.Extra.toUrlRequest location href)) program state
 
                 Nothing ->
                     Err (ChangedPage functionDescription (Url.Extra.resolve location href))
@@ -176,13 +176,13 @@ urlChangeHelper functionName removeFromBackStack url program state =
                     Url.Extra.resolve currentLocation url
 
                 processRouteChange =
-                    case program.onUrlChange newLocation of
+                    case program.onUrlChange of
                         Nothing ->
                             Ok
 
-                        Just msg ->
+                        Just onUrlChange ->
                             -- TODO: should this be set before or after?
-                            update msg program
+                            update (onUrlChange newLocation) program
             in
             { state
                 | navigation =

--- a/src/TestState.elm
+++ b/src/TestState.elm
@@ -1,12 +1,11 @@
-module TestState exposing (TestState, advanceTime, drain, queueEffect, simulateLoadUrlHelper, update, urlChangeHelper, urlRequestHelper, withSimulation)
+module TestState exposing (TestState, advanceTime, drain, queueEffect, update, urlChangeHelper, urlRequestHelper, withSimulation)
 
-import Browser
 import Dict
 import PairingHeap
 import ProgramTest.EffectSimulation as EffectSimulation exposing (EffectSimulation)
 import ProgramTest.Failure exposing (Failure(..))
 import ProgramTest.Program exposing (Program)
-import SimulatedEffect exposing (SimulatedEffect, SimulatedSub)
+import SimulatedEffect exposing (SimulatedEffect)
 import String.Extra
 import Url exposing (Url)
 import Url.Extra

--- a/src/Url/Extra.elm
+++ b/src/Url/Extra.elm
@@ -16,7 +16,10 @@ resolve base url =
         |> Maybe.withDefault
             { base
                 | path =
-                    if String.startsWith "/" url then
+                    if String.startsWith "#" url || String.startsWith "?" url then
+                        base.path
+
+                    else if String.startsWith "/" url then
                         url
 
                     else
@@ -26,6 +29,16 @@ resolve base url =
                             |> List.reverse
                             |> (\l -> l ++ String.split "/" url)
                             |> String.join "/"
-                , query = Nothing
-                , fragment = Nothing
+                , query =
+                    if String.startsWith "?" url then
+                        Just (String.dropLeft 1 url)
+
+                    else
+                        Nothing
+                , fragment =
+                    if String.startsWith "#" url then
+                        Just (String.dropLeft 1 url)
+
+                    else
+                        Nothing
             }

--- a/src/Url/Extra.elm
+++ b/src/Url/Extra.elm
@@ -12,28 +12,28 @@ import Url exposing (Protocol(..), Url)
 -}
 resolve : Url -> String -> Url
 resolve base url =
-    -- TODO: This passes all the tests (except one), but could probably be nicer. The query and fragment don't necessarily end up in the right place in the record.
+    -- TODO: This passes all the tests (except one), but could probably be nicer.
     case Url.fromString url of
         Just newUrl ->
             newUrl
 
         Nothing ->
-            if String.isEmpty url then
+            (if String.isEmpty url then
                 base
 
-            else if String.startsWith "#" url then
+             else if String.startsWith "#" url then
                 { base | fragment = Just (String.dropLeft 1 url) }
 
-            else if String.startsWith "?" url then
+             else if String.startsWith "?" url then
                 { base
                     | query = Just (String.dropLeft 1 url)
                     , fragment = Nothing
                 }
 
-            else if String.startsWith "//" url then
+             else if String.startsWith "//" url then
                 { base | host = String.dropLeft 2 url, path = "", fragment = Nothing, query = Nothing }
 
-            else
+             else
                 { base
                     | path =
                         if String.startsWith "/" url then
@@ -67,6 +67,13 @@ resolve base url =
                     , fragment = Nothing
                     , query = Nothing
                 }
+            )
+                |> (\u ->
+                        -- pass back through Url.fromString just to get the query and fragment in the right place
+                        Url.toString u
+                            |> Url.fromString
+                            |> Maybe.withDefault u
+                   )
 
 
 parseDoubleDots : String -> List String -> String

--- a/src/Url/Extra.elm
+++ b/src/Url/Extra.elm
@@ -1,44 +1,93 @@
-module Url.Extra exposing (resolve)
+module Url.Extra exposing (resolve, toUrlRequest)
 
 {-| TODO: this module should implement the algorithm described at
 <https://url.spec.whatwg.org/>
 -}
 
-import Url exposing (Url)
+import Browser
+import Url exposing (Protocol(..), Url)
 
 
 {-| This resolves a URL string (either an absolute or relative URL) against a base URL (given as a `Location`).
 -}
 resolve : Url -> String -> Url
 resolve base url =
-    Url.fromString url
-        -- TODO: implement correct logic (current logic is only correct for "authority-relative" URLs without query or fragment strings)
-        |> Maybe.withDefault
-            { base
-                | path =
-                    if String.startsWith "#" url || String.startsWith "?" url then
-                        base.path
+    -- TODO: This passes all the tests (except one), but could probably be nicer. The query and fragment don't necessarily end up in the right place in the record.
+    case Url.fromString url of
+        Just newUrl ->
+            newUrl
 
-                    else if String.startsWith "/" url then
-                        url
+        Nothing ->
+            if String.isEmpty url then
+                base
 
-                    else
-                        String.split "/" base.path
-                            |> List.reverse
-                            |> List.drop 1
-                            |> List.reverse
-                            |> (\l -> l ++ String.split "/" url)
-                            |> String.join "/"
-                , query =
-                    if String.startsWith "?" url then
-                        Just (String.dropLeft 1 url)
+            else if String.startsWith "#" url then
+                { base | fragment = Just (String.dropLeft 1 url) }
 
-                    else
-                        Nothing
-                , fragment =
-                    if String.startsWith "#" url then
-                        Just (String.dropLeft 1 url)
+            else if String.startsWith "?" url then
+                { base
+                    | query = Just (String.dropLeft 1 url)
+                    , fragment = Nothing
+                }
 
-                    else
-                        Nothing
-            }
+            else if String.startsWith "//" url then
+                { base | host = String.dropLeft 2 url, path = "", fragment = Nothing, query = Nothing }
+
+            else
+                { base
+                    | path =
+                        if String.startsWith "/" url then
+                            url
+
+                        else if url == ".." || String.startsWith "../" url then
+                            String.split "/" base.path
+                                |> List.reverse
+                                |> List.drop 1
+                                |> parseDoubleDots url
+
+                        else
+                            String.split "/" base.path
+                                |> List.reverse
+                                |> List.drop 1
+                                |> List.reverse
+                                |> (\l ->
+                                        l
+                                            ++ String.split "/"
+                                                (if String.startsWith "./" url then
+                                                    String.dropLeft 2 url
+
+                                                 else if String.startsWith "." url then
+                                                    String.dropLeft 1 url
+
+                                                 else
+                                                    url
+                                                )
+                                   )
+                                |> String.join "/"
+                    , fragment = Nothing
+                    , query = Nothing
+                }
+
+
+parseDoubleDots : String -> List String -> String
+parseDoubleDots url pathSegments =
+    if String.startsWith "../" url then
+        parseDoubleDots (String.dropLeft 3 url) (List.drop 1 pathSegments)
+
+    else if String.startsWith ".." url then
+        parseDoubleDots (String.dropLeft 2 url) (List.drop 1 pathSegments)
+
+    else
+        String.join "/" (List.reverse pathSegments) ++ "/" ++ url
+
+
+toUrlRequest : Url -> String -> Browser.UrlRequest
+toUrlRequest base href =
+    resolve base href
+        |> (\url ->
+                if url.protocol == base.protocol && url.host == base.host && url.port_ == base.port_ then
+                    Browser.Internal url
+
+                else
+                    Browser.External href
+           )

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -33,6 +33,16 @@ all =
                 TestingProgram.application SimulatedEffect.Cmd.none
                     |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.pushUrl "new"))
                     |> ProgramTest.expectBrowserUrl (Expect.equal "https://example.com/new")
+        , test "simulating a pushUrl with a relative URL containing a query and fragment triggers an onUrlChange" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.Cmd.none
+                    |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.pushUrl "new?query#fragment"))
+                    |> ProgramTest.expectModel (Expect.equal [ "OnUrlChange: https://example.com/new?query#fragment" ])
+        , test "simulating a pushUrl with a relative URL containing a query changes the browser URL" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.Cmd.none
+                    |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.pushUrl "new?query#fragment"))
+                    |> ProgramTest.expectBrowserUrl (Expect.equal "https://example.com/new?query#fragment")
         , test "simulating a replaceUrl triggers an onUrlChange" <|
             \() ->
                 TestingProgram.application SimulatedEffect.Cmd.none

--- a/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/NavigationTest.elm
@@ -8,8 +8,6 @@ import SimulatedEffect.Navigation
 import Test exposing (..)
 import Test.Expect exposing (expectFailure)
 import TestingProgram exposing (Msg(..))
-import Url.Parser as Parser exposing ((</>), (<?>))
-import Url.Parser.Query as QueryParser
 
 
 all : Test
@@ -118,45 +116,4 @@ all =
                 TestingProgram.application SimulatedEffect.Cmd.none
                     |> ProgramTest.expectPageChange "https://example.com/"
                     |> expectFailure [ "expectPageChange: expected to have navigated to a different URL, but no links were clicked and no browser navigation was simulated" ]
-        , pushUrlWithQueryAndFragment
-        ]
-
-
-pushUrlWithQueryAndFragment : Test
-pushUrlWithQueryAndFragment =
-    describe "simulating pushUrl with query and/or fragment and parsing the result gives the correct route" <|
-        let
-            parser =
-                Parser.map
-                    (\q f ->
-                        "NEW"
-                            ++ (Maybe.map ((++) " QUERY:") q |> Maybe.withDefault "")
-                            ++ (Maybe.map ((++) " FRAGMENT:") f |> Maybe.withDefault "")
-                    )
-                    (Parser.s "new" <?> QueryParser.string "query" </> Parser.fragment identity)
-
-            check url expected =
-                test ("pushUrl " ++ url) <|
-                    \_ ->
-                        ProgramTest.createApplication
-                            { onUrlChange = \location -> Log ("Route: " ++ (Parser.parse parser location |> Maybe.withDefault "NOMATCH"))
-                            , onUrlRequest = \_ -> Debug.todo "ProgramTestTests-2:onUrlRequest"
-                            , init = \() location key -> ( [], SimulatedEffect.Cmd.none )
-                            , update = TestingProgram.update
-                            , view =
-                                \_ ->
-                                    { title = "page title"
-                                    , body = []
-                                    }
-                            }
-                            |> ProgramTest.withSimulatedEffects identity
-                            |> ProgramTest.withBaseUrl "https://example.com/path"
-                            |> ProgramTest.start ()
-                            |> ProgramTest.update (ProduceEffects (SimulatedEffect.Navigation.pushUrl url))
-                            |> ProgramTest.expectModel (Expect.equal [ "Route: " ++ expected ])
-        in
-        [ check "new" "NEW"
-        , check "new?query=q" "NEW QUERY:q"
-        , check "new#fragment" "NEW FRAGMENT:fragment"
-        , check "new?query=q#fragment" "NEW QUERY:q FRAGMENT:fragment"
         ]

--- a/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
@@ -80,6 +80,8 @@ all =
             \() ->
                 TestingProgram.application SimulatedEffect.None
                     |> ProgramTest.clickLink "SPA" "/search?q=query"
+                    |> ProgramTest.ensureBrowserHistory (Expect.equal [ "https://example.com/path" ])
+                    |> ProgramTest.ensureBrowserUrl (Expect.equal "https://example.com/search?q=query")
                     |> ProgramTest.expectModel (Expect.equal [ "OnUrlChange: https://example.com/search?q=query" ])
         , test "external link changes page" <|
             \() ->

--- a/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
@@ -1,11 +1,12 @@
 module ProgramTestTests.UserInput.ClickLinkTest exposing (all)
 
 import Expect
-import Html exposing (Html)
+import Html
 import Html.Attributes exposing (href)
 import Html.Events
 import Json.Decode
 import ProgramTest exposing (ProgramTest)
+import SimulatedEffect
 import Test exposing (..)
 import Test.Expect exposing (expectFailure)
 import TestingProgram exposing (Msg(..))
@@ -52,7 +53,7 @@ all =
                 linkProgram
                     |> ProgramTest.clickLink "Relative" "/settings"
                     |> ProgramTest.expectPageChange "http://localhost:3000/settings"
-        , test "can verify an internal (single-page app) link" <|
+        , test "can verify an internal (single-page app) link with onClick handler" <|
             \() ->
                 ProgramTest.createApplication
                     { onUrlChange = .path
@@ -75,6 +76,16 @@ all =
                     |> ProgramTest.start ()
                     |> ProgramTest.clickLink "SPA" "#search"
                     |> ProgramTest.expectModel (Expect.equal "<INIT:/>;GoToSearch")
+        , test "internal (single-page app) link causes url change" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.None
+                    |> ProgramTest.clickLink "SPA" "/search?q=query"
+                    |> ProgramTest.expectModel (Expect.equal [ "OnUrlChange: https://example.com/search?q=query" ])
+        , test "external link changes page" <|
+            \() ->
+                TestingProgram.application SimulatedEffect.None
+                    |> ProgramTest.clickLink "External" "http://external.com/test"
+                    |> ProgramTest.expectPageChange "http://external.com/test"
         , test "gives accessibility advice for links with bad onClick" <|
             \() ->
                 TestingProgram.startView

--- a/tests/Url/ExtraTest.elm
+++ b/tests/Url/ExtraTest.elm
@@ -34,6 +34,11 @@ all =
             , check "https://example.com/path?query#fragment" "?q" "https://example.com/path?q"
             , check "https://example.com/path?query#fragment" "" "https://example.com/path?query#fragment"
             , check "https://example.com/path?query#fragment" "../path2" "https://example.com/path2"
+            , check "https://example.com/path" "/new?q#f" "https://example.com/new?q#f"
+            , check "https://example.com/path" "/new?q" "https://example.com/new?q"
+            , check "https://example.com/path" "/new#f" "https://example.com/new#f"
+            , check "https://example.com/path" "//new.example.com?q#f" "https://new.example.com?q#f"
+            , check "https://example.com/path" "//new.example.com/new?q#f" "https://new.example.com/new?q#f"
             , describe "W3 reference examples" <|
                 let
                     baseUri =

--- a/tests/Url/ExtraTest.elm
+++ b/tests/Url/ExtraTest.elm
@@ -46,7 +46,7 @@ all =
                     , check baseUri "./g" "http://a/b/c/g"
                     , check baseUri "g/" "http://a/b/c/g/"
                     , check baseUri "/g" "http://a/g"
-                    , check baseUri "//g" "http://g"
+                    , check baseUri "//g" "http://g/" -- In 5.4.1 Normal Examples this is "http://g", but Url.Parser defaults to "/" for empty path segment
                     , check baseUri "?y" "http://a/b/c/d;p?y"
                     , check baseUri "g?y" "http://a/b/c/g?y"
                     , check baseUri "#s" "http://a/b/c/d;p?q#s"

--- a/tests/Url/ExtraTest.elm
+++ b/tests/Url/ExtraTest.elm
@@ -20,9 +20,8 @@ all =
                                     Expect.fail ("Unable to parse base url: " ++ base)
 
                                 Just b ->
-                                    Url.Extra.resolve b relative
-                                        |> Url.toString
-                                        |> Expect.equal expected
+                                    Just (Url.Extra.resolve b relative)
+                                        |> Expect.equal (Url.fromString expected)
             in
             [ check "https://example.com/path" "https://example.com/new" "https://example.com/new"
             , check "https://example.com/path" "/new" "https://example.com/new"

--- a/tests/Url/ExtraTest.elm
+++ b/tests/Url/ExtraTest.elm
@@ -1,5 +1,6 @@
 module Url.ExtraTest exposing (all)
 
+import Browser exposing (UrlRequest(..))
 import Expect
 import Test exposing (..)
 import Url
@@ -28,6 +29,12 @@ all =
             , check "https://example.com/path" "new" "https://example.com/new"
             , check "https://example.com/path/file" "new" "https://example.com/path/new"
             , check "https://example.com/path?query#fragment" "new" "https://example.com/new"
+            , check "https://example.com/path?query#fragment" "new?q#f" "https://example.com/new?q#f"
+            , check "https://example.com/path?query#fragment" "?q#f" "https://example.com/path?q#f"
+            , check "https://example.com/path?query#fragment" "#f" "https://example.com/path?query#f"
+            , check "https://example.com/path?query#fragment" "?q" "https://example.com/path?q"
+            , check "https://example.com/path?query#fragment" "" "https://example.com/path?query#fragment"
+            , check "https://example.com/path?query#fragment" "../path2" "https://example.com/path2"
             , describe "W3 reference examples" <|
                 let
                     baseUri =
@@ -36,32 +43,60 @@ all =
                 [ describe "5.4.1 Normal Examples"
                     [ -- check baseUri "g:h" "g:h"
                       check baseUri "g" "http://a/b/c/g"
-
-                    -- , check baseUri "./g" "http://a/b/c/g"
+                    , check baseUri "./g" "http://a/b/c/g"
                     , check baseUri "g/" "http://a/b/c/g/"
                     , check baseUri "/g" "http://a/g"
-
-                    -- , check baseUri "//g" "http://g"
-                    -- , check baseUri "?y" "http://a/b/c/d;p?y"
+                    , check baseUri "//g" "http://g"
+                    , check baseUri "?y" "http://a/b/c/d;p?y"
                     , check baseUri "g?y" "http://a/b/c/g?y"
-
-                    -- , check baseUri "#s" "http://a/b/c/d;p?q#s"
+                    , check baseUri "#s" "http://a/b/c/d;p?q#s"
                     , check baseUri "g#s" "http://a/b/c/g#s"
                     , check baseUri "g?y#s" "http://a/b/c/g?y#s"
                     , check baseUri ";x" "http://a/b/c/;x"
                     , check baseUri "g;x" "http://a/b/c/g;x"
                     , check baseUri "g;x?y#s" "http://a/b/c/g;x?y#s"
-
-                    -- , check baseUri "" "http://a/b/c/d;p?q"
-                    -- , check baseUri "." "http://a/b/c/"
-                    -- , check baseUri "./" "http://a/b/c/"
-                    -- , check baseUri ".." "http://a/b/"
-                    -- , check baseUri "../" "http://a/b/"
-                    -- , check baseUri "../g" "http://a/b/g"
-                    -- , check baseUri "../.." "http://a/"
-                    -- , check baseUri "../../" "http://a/"
-                    -- , check baseUri "../../g" "http://a/g"
+                    , check baseUri "" "http://a/b/c/d;p?q"
+                    , check baseUri "." "http://a/b/c/"
+                    , check baseUri "./" "http://a/b/c/"
+                    , check baseUri ".." "http://a/b/"
+                    , check baseUri "../" "http://a/b/"
+                    , check baseUri "../g" "http://a/b/g"
+                    , check baseUri "../.." "http://a/"
+                    , check baseUri "../../" "http://a/"
+                    , check baseUri "../../g" "http://a/g"
                     ]
                 ]
+            ]
+        , describe "toUrlRequest" <|
+            let
+                requestToString req =
+                    case req of
+                        Internal url ->
+                            "INTERNAL:" ++ Url.toString url
+
+                        External href ->
+                            "EXTERNAL:" ++ href
+
+                check base relative expected =
+                    test ("resolve " ++ base ++ " " ++ relative) <|
+                        \() ->
+                            case Url.fromString base of
+                                Nothing ->
+                                    Expect.fail ("Unable to parse base url: " ++ base)
+
+                                Just b ->
+                                    Url.Extra.toUrlRequest b relative
+                                        |> requestToString
+                                        |> Expect.equal expected
+            in
+            [ check "https://example.com/path" "https://example.com/new" "INTERNAL:https://example.com/new"
+            , check "https://example.com/path" "/new" "INTERNAL:https://example.com/new"
+            , check "https://example.com/path" "new" "INTERNAL:https://example.com/new"
+            , check "https://example.com/path/file" "new?query#fragment" "INTERNAL:https://example.com/path/new?query#fragment"
+            , check "https://example.com/path?query#fragment" "new" "INTERNAL:https://example.com/new"
+            , check "http://localhost:3000" "http://localhost:3000/new" "INTERNAL:http://localhost:3000/new"
+            , check "https://example.com/path/file" "https://example2.com/new" "EXTERNAL:https://example2.com/new"
+            , check "https://example.com/path/file" "http://example.com/path/file" "EXTERNAL:http://example.com/path/file"
+            , check "http://localhost:3000" "http://localhost:5000" "EXTERNAL:http://localhost:5000"
             ]
         ]


### PR DESCRIPTION
Hello

I recently ran into [Issue #107](https://github.com/avh4/elm-program-test/issues/107) while using this excellent package. I also found a related issue where using `pushUrl` with a query and/or fragment and then parsing the resulting URL would fail to give the correct results. This PR attempts to address both of these.

The tests added in `ClickLinkTest` and `NavigationTest` would fail in the current version.

The implementation of `Url.Extra.resolve` could probably be done in a nicer way but for now it seems to serve the purpose and hopefully is an improvement at least.

All feedback and modifications gratefully received.

Closes #107 

- [X] ran tests locally with `npm test`
- [X] updated CHANGELOG.md if appropriate


