### PR TITLE
Make clickLink look for links with aria-label and alt text

### DIFF
--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -210,6 +210,7 @@ import ProgramTest.ComplexQuery as ComplexQuery exposing (ComplexQuery)
 import ProgramTest.EffectSimulation as EffectSimulation exposing (EffectSimulation)
 import ProgramTest.Failure as Failure exposing (Failure(..))
 import ProgramTest.Program as Program exposing (Program)
+import Result.Extra
 import SimulatedEffect exposing (SimulatedEffect, SimulatedSub, SimulatedTask)
 import String.Extra
 import Test.Html.Event
@@ -1068,15 +1069,11 @@ clickLink linkText href =
                 ]
             )
 
-        simulateEventOnLink event single =
+        respondsTo event single =
             single
                 |> Test.Html.Event.simulate event
                 |> Test.Html.Event.toResult
-
-        respondsTo event single =
-            simulateEventOnLink event single
-                |> Result.toMaybe
-                |> (/=) Nothing
+                |> Result.Extra.isOk
 
         tryClicking :
             { otherwise :
@@ -1108,7 +1105,9 @@ clickLink linkText href =
 
                 else
                     -- everything looks good, so simulate that event and ignore the `href`
-                    simulateEventOnLink normalClick single
+                    single
+                        |> Test.Html.Event.simulate normalClick
+                        |> Test.Html.Event.toResult
                         |> Result.mapError (SimulateFailed functionDescription)
                         |> Result.andThen (\msg -> TestState.update msg program state)
 

--- a/src/ProgramTest/ComplexQuery.elm
+++ b/src/ProgramTest/ComplexQuery.elm
@@ -3,6 +3,7 @@ module ProgramTest.ComplexQuery exposing (ComplexQuery, Failure(..), FailureCont
 import Json.Encode as Json
 import ProgramTest.TestHtmlHacks as TestHtmlHacks
 import ProgramTest.TestHtmlParser as TestHtmlParser
+import Result.Extra
 import Set exposing (Set)
 import Test.Html.Event
 import Test.Html.Query as Query
@@ -356,14 +357,4 @@ firstErrorOf source choices =
 
 countSuccesses : List (Result String String) -> Int
 countSuccesses results =
-    List.length (List.filter isOk results)
-
-
-isOk : Result x a -> Bool
-isOk result =
-    case result of
-        Ok _ ->
-            True
-
-        Err _ ->
-            False
+    List.length (List.filter Result.Extra.isOk results)

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -1,0 +1,11 @@
+module Result.Extra exposing (isOk)
+
+
+isOk : Result x a -> Bool
+isOk result =
+    case result of
+        Ok _ ->
+            True
+
+        Err _ ->
+            False

--- a/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
@@ -34,6 +34,12 @@ linkProgram =
                 Html.div []
                     [ Html.a [ href "https://example.com/link" ] [ Html.text "External" ]
                     , Html.a [ href "/settings" ] [ Html.text "Relative" ]
+                    , Html.a
+                        [ href "https://example.com/link"
+                        , Html.Attributes.attribute "aria-label" "Aria"
+                        ]
+                        []
+                    , Html.a [ href "https://example.com/link" ] [ Html.img [ Html.Attributes.alt "Alt Text" ] [] ]
                     ]
         }
         |> ProgramTest.withBaseUrl "http://localhost:3000/Main.elm"
@@ -47,6 +53,16 @@ all =
             \() ->
                 linkProgram
                     |> ProgramTest.clickLink "External" "https://example.com/link"
+                    |> ProgramTest.expectPageChange "https://example.com/link"
+        , test "can verify a link with aria-label" <|
+            \() ->
+                linkProgram
+                    |> ProgramTest.clickLink "Aria" "https://example.com/link"
+                    |> ProgramTest.expectPageChange "https://example.com/link"
+        , test "can verify a link with img and alt text" <|
+            \() ->
+                linkProgram
+                    |> ProgramTest.clickLink "Alt Text" "https://example.com/link"
                     |> ProgramTest.expectPageChange "https://example.com/link"
         , test "can verify a relative link" <|
             \() ->


### PR DESCRIPTION
Hi @avh4. While I was on a roll I decided to have a look at #158, because I'm also running into this issue where I am using icons in links with an aria-label.

See what you think.

Closes #158 

- [x] ran tests locally with `npm test`
- [ ] updated CHANGELOG.md if appropriate