### PR TITLE
Add SimulatedEffect.Task.sequence

### DIFF
--- a/src/SimulatedEffect/Task.elm
+++ b/src/SimulatedEffect/Task.elm
@@ -99,9 +99,7 @@ fail =
 
 
 {-| Start with a list of tasks, and turn them into a single task that returns a
-list. The tasks will be run in order one-by-one and if any task fails the whole
-sequence fails.
-sequence [ succeed 1, succeed 2 ] == succeed [ 1, 2 ]
+list.
 -}
 sequence : List (SimulatedTask x a) -> SimulatedTask x (List a)
 sequence tasks =

--- a/src/SimulatedEffect/Task.elm
+++ b/src/SimulatedEffect/Task.elm
@@ -1,6 +1,6 @@
 module SimulatedEffect.Task exposing
     ( perform, attempt
-    , andThen, succeed, fail
+    , andThen, succeed, fail, sequence
     , map, map2, map3, map4, map5
     , mapError, onError
     )
@@ -20,7 +20,7 @@ to help you implement the function to provide when using [`ProgramTest.withSimul
 
 # Chains
 
-@docs andThen, succeed, fail
+@docs andThen, succeed, fail, sequence
 
 
 # Maps
@@ -96,6 +96,16 @@ succeed =
 fail : x -> SimulatedTask x a
 fail =
     SimulatedEffect.Fail
+
+
+{-| Start with a list of tasks, and turn them into a single task that returns a
+list. The tasks will be run in order one-by-one and if any task fails the whole
+sequence fails.
+sequence [ succeed 1, succeed 2 ] == succeed [ 1, 2 ]
+-}
+sequence : List (SimulatedTask x a) -> SimulatedTask x (List a)
+sequence tasks =
+    List.foldr (map2 (::)) (succeed []) tasks
 
 
 {-| Transform a task.

--- a/tests/ProgramTestTests/SimulatedEffects/BasicTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/BasicTest.elm
@@ -28,4 +28,12 @@ all =
             \() ->
                 startTask (Task.succeed 5 |> Task.andThen ((+) 10 >> Task.fail))
                     |> ProgramTest.expectModel (Expect.equal [ "Err 15" ])
+        , test "simulated Task.sequence" <|
+            \() ->
+                startTask (Task.sequence [ Task.succeed 1, Task.succeed 2 ])
+                    |> ProgramTest.expectModel (Expect.equal [ "Ok [1,2]" ])
+        , test "simulated Task.sequence fail" <|
+            \() ->
+                startTask (Task.sequence [ Task.succeed 1, Task.fail () ])
+                    |> ProgramTest.expectModel (Expect.equal [ "Err ()" ])
         ]


### PR DESCRIPTION
I was about to simulate Task.sequence, and noticed it wasn't there.

- [x] ran tests locally with `npm test`
- [ ] updated CHANGELOG.md if appropriate
