### PR TITLE
Parse query find always expects 1 element error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ New features:
 
 - `clickLink` now works for internal links when testing a `Browser.application`
 - `pushUrl` now works properly for relative urls with query and/or fragment
+- `clickLink` looks for links with aria-label or containing img with alt text
+- Added `SimulatedEffect.Task.sequence`
 
+Bug fixes:
+
+- Parses `Query.find always expects to find 1 element` errors
 
 ## 3.6.3
 

--- a/src/ProgramTest/ComplexQuery.elm
+++ b/src/ProgramTest/ComplexQuery.elm
@@ -348,6 +348,9 @@ firstErrorOf source choices =
                         Ok (TestHtmlParser.EventFailure name _) ->
                             [ Err ("PLEASE REPORT THIS AT <https://github.com/avh4/elm-program-test/issues>: firstErrorOf: got unexpected EventFailure \"" ++ name ++ "\"") ]
 
+                        Ok (TestHtmlParser.MultipleElementsFailure _) ->
+                            [ Err "PLEASE REPORT THIS AT <https://github.com/avh4/elm-program-test/issues>: firstErrorOf: got unexpected MultipleElementsFailure" ]
+
                         Err err ->
                             [ Err ("PLEASE REPORT THIS AT <https://github.com/avh4/elm-program-test/issues>: firstErrorOf: couldn't parse failure report: " ++ err) ]
 

--- a/src/ProgramTest/TestHtmlHacks.elm
+++ b/src/ProgramTest/TestHtmlHacks.elm
@@ -38,6 +38,9 @@ renderHtml colorHidden highlightPredicate single =
         Ok (EventFailure name _) ->
             pleaseReport ("renderHtml: unexpected EventFailure: \"" ++ name ++ "\"")
 
+        Ok (MultipleElementsFailure _) ->
+            pleaseReport "renderHtml: unexpected MultipleElementsFailure"
+
         Err err ->
             pleaseReport ("renderHtml: couldn't parse failure report: " ++ err)
 
@@ -58,6 +61,9 @@ getPassingSelectors selectors single =
 
         Err err ->
             [ pleaseReport ("getPassingSelectors: couldn't parse failure report: " ++ err) ]
+
+        Ok (MultipleElementsFailure _) ->
+            [ pleaseReport "getPassingSelectors: got unexpected MultipleElementsFailure" ]
 
 
 forceFailureReport : List Selector -> Query.Single any -> Result String (FailureReport Html.Parser.Node)
@@ -123,6 +129,9 @@ parseSimulateFailure string =
             case result of
                 EventFailure name html ->
                     Ok ("Event.expectEvent: I found a node, but it does not listen for \"" ++ name ++ "\" events like I expected it would.")
+
+                MultipleElementsFailure num ->
+                    Ok ("Query.find always expects to find 1 element, but it found " ++ String.fromInt num ++ " instead.")
 
                 _ ->
                     Err (pleaseReport "Got a failure message from Test.Html.Query that we couldn't parse: " ++ string)

--- a/src/ProgramTest/TestHtmlParser.elm
+++ b/src/ProgramTest/TestHtmlParser.elm
@@ -9,6 +9,7 @@ import ProgramTest.HtmlParserHacks as HtmlParserHacks
 type FailureReport html
     = QueryFailure html (List (Step html)) Assertion
     | EventFailure String html
+    | MultipleElementsFailure Int
 
 
 type Step html
@@ -44,6 +45,10 @@ parser_ parseHtml =
             |. Parser.symbol "\" events like I expected it would.\n\n"
             |= parseHtml
             |. Parser.end
+        , Parser.succeed MultipleElementsFailure
+            |. Parser.symbol "Query.find always expects to find 1 element, but it found "
+            |= Parser.int
+            |. Parser.symbol " instead."
         ]
 
 

--- a/tests/ProgramTest/TestHtmlHacksTest.elm
+++ b/tests/ProgramTest/TestHtmlHacksTest.elm
@@ -186,6 +186,13 @@ all =
                                     )
                                 )
                             )
+            , Test.test "parses Query.find always expects to find 1 element error" <|
+                \() ->
+                    parse
+                        [ "Query.find always expects to find 1 element, but it found 2 instead."
+                        , "HINT: If you actually expected 2 elements, use Query.findAll instead of Query.find."
+                        ]
+                        |> Expect.equal (Ok (MultipleElementsFailure 2))
             ]
         ]
 


### PR DESCRIPTION
Hi @avh4. In the interests of helping get your next release out, I thought I'd attempt to tackle issue #154 which is on the milestone. Not totally sure about the naming of `MultipleElementsFailure`. Let me know what you think.

- [x]  Add a failing test in `tests/ProgramTestTests/UserInput/ClickButtonTest.elm`
- [x]  grab the current error message from that and use it to add a test in `tests/ProgramTest/TestHtmlHacksTest.elm`
- [x]  implement parsing of the error message in `src/ProgramTest/TestHtmlParser.elm`
- [x]  make sure tests pass now
- [x]  update CHANGELOG.md
- [x]  PR should be made against or switched to the "develop" branch (not "main")

Closes #154
