### PR TITLE
Upgrade to elm-explorations/test 2.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -28,7 +28,7 @@
         "elm/time": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
         "elm-community/list-extra": "8.0.0 <= v < 9.0.0",
-        "elm-explorations/test": "1.2.1 <= v < 2.0.0",
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0",
         "hecrj/html-parser": "2.3.3 <= v < 3.0.0",
         "mgold/elm-nonempty-list": "4.0.0 <= v < 5.0.0"
     },

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -30,7 +30,7 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2"
+            "elm-explorations/test": "2.0.1"
         },
         "indirect": {}
     }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^7.3.0",
     "elm-doc-preview": "^5.0.5",
-    "elm-test": "^0.19.1-revision9",
-    "elm-tooling": "^1.8.0",
+    "elm-test": "^0.19.1-revision10",
+    "elm-tooling": "^1.9.0",
     "vuepress": "^1.9.7"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ specifiers:
   chokidar-cli: ^3.0.0
   concurrently: ^7.3.0
   elm-doc-preview: ^5.0.5
-  elm-test: ^0.19.1-revision9
-  elm-tooling: ^1.8.0
+  elm-test: ^0.19.1-revision10
+  elm-tooling: ^1.9.0
   vuepress: ^1.9.7
 
 devDependencies:
@@ -14,8 +14,8 @@ devDependencies:
   chokidar-cli: 3.0.0
   concurrently: 7.3.0
   elm-doc-preview: 5.0.5
-  elm-test: 0.19.1-revision9
-  elm-tooling: 1.8.0
+  elm-test: 0.19.1-revision10
+  elm-tooling: 1.9.0
   vuepress: 1.9.7
 
 packages:
@@ -3644,8 +3644,8 @@ packages:
     resolution: {integrity: sha512-A05XKZKhzM8vWTo8KvNR4g1ICt9iMPOAMfo79OK25c+tQaLSfQ8iMYvW6XgSEd+SgRfM5VSKX4hKEiH6iTiWsg==}
     dev: true
 
-  /elm-test/0.19.1-revision9:
-    resolution: {integrity: sha512-lvHJbh16sy7oUBBPIEMN+0v6dGDZFmfvwq+V+TnGPk5ZlI64vcykx8E8+zLt/E+Ja42UKMMXXgN1ZHQ1V6Ic2Q==}
+  /elm-test/0.19.1-revision10:
+    resolution: {integrity: sha512-33jXpA15alVcYjX+UJOkiOmQIQxjd3c0eeg3960VyhEf8tG8O4g4B5ipMmu6KAllncrSxSQrYzKJnNJM/8ZiCg==}
     engines: {node: '>=12.20.0'}
     hasBin: true
     dependencies:
@@ -3661,8 +3661,8 @@ packages:
       xmlbuilder: 15.1.1
     dev: true
 
-  /elm-tooling/1.8.0:
-    resolution: {integrity: sha512-IjMvW/VHqxLidlJSAocBGDBmqiZ1NS0lK/UCMRU4ULEEaTVjpSd/9Dv0mH2ok0H0egSTYx19GnrdL4Lq9h+z+A==}
+  /elm-tooling/1.9.0:
+    resolution: {integrity: sha512-FuMsshhsnjAizktA/j5JWLHLHZDt6CSmXbGQZtgOTNz86Z9eUxTupoZZ8czpW2aRWBUiD6IhJNWDQjJsgNuEIg==}
     hasBin: true
     dev: true
 

--- a/src/ProgramTest/Failure.elm
+++ b/src/ProgramTest/Failure.elm
@@ -8,6 +8,8 @@ import String.Extra
 import Test.Html.Query as Query
 import Test.Runner.Failure
 import Url exposing (Url)
+import Vendored.Failure
+import Vendored.FormatMonochrome
 
 
 type Failure
@@ -35,7 +37,12 @@ toString failure =
             cause ++ " caused the program to end by navigating to " ++ String.Extra.escape (Url.toString finalLocation) ++ ".  NOTE: If this is what you intended, use ProgramTest.expectPageChange to end your test."
 
         ExpectFailed expectationName description reason ->
-            expectationName ++ ":\n" ++ Test.Runner.Failure.format description reason
+            expectationName
+                ++ ":\n"
+                ++ Vendored.Failure.format
+                    Vendored.FormatMonochrome.formatEquality
+                    description
+                    reason
 
         SimulateFailed functionName message ->
             functionName ++ ":\n" ++ message

--- a/src/Vendored/Diff.elm
+++ b/src/Vendored/Diff.elm
@@ -1,0 +1,321 @@
+-- NOTE: This is copy/pasted from https://github.com/jinjor/elm-diff
+-- License:
+{-
+   Copyright (c) 2016, Yosuke Torii
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+   * Neither the name of elm-diff nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-}
+
+
+module Vendored.Diff exposing
+    ( Change(..)
+    , diff
+    )
+
+{-| Compares two list and returns how they have changed.
+Each function internally uses Wu's [O(NP) algorithm](http://myerslab.mpi-cbg.de/wp-content/uploads/2014/06/np_diff.pdf).
+
+
+# Types
+
+@docs Change
+
+
+# Diffing
+
+@docs diff, diffLines
+
+-}
+
+import Array exposing (Array)
+
+
+{-| This describes how each line has changed and also contains its value.
+-}
+type Change a
+    = Added a
+    | Removed a
+    | NoChange a
+
+
+type StepResult
+    = Continue (Array (List ( Int, Int )))
+    | Found (List ( Int, Int ))
+
+
+type BugReport
+    = CannotGetA Int
+    | CannotGetB Int
+    | UnexpectedPath ( Int, Int ) (List ( Int, Int ))
+
+
+{-| Compares general lists.
+
+    diff [ 1, 3 ] [ 2, 3 ] == [ Removed 1, Added 2, NoChange 3 ] -- True
+
+-}
+diff : List a -> List a -> List (Change a)
+diff a b =
+    case testDiff a b of
+        Ok changes ->
+            changes
+
+        Err _ ->
+            []
+
+
+{-| Test the algolithm itself.
+If it returns Err, it should be a bug.
+-}
+testDiff : List a -> List a -> Result BugReport (List (Change a))
+testDiff a b =
+    let
+        arrA =
+            Array.fromList a
+
+        arrB =
+            Array.fromList b
+
+        m =
+            Array.length arrA
+
+        n =
+            Array.length arrB
+
+        -- Elm's Array doesn't allow null element,
+        -- so we'll use shifted index to access source.
+        getA =
+            \x -> Array.get (x - 1) arrA
+
+        getB =
+            \y -> Array.get (y - 1) arrB
+
+        path =
+            -- Is there any case ond is needed?
+            -- ond getA getB m n
+            onp getA getB m n
+    in
+    makeChanges getA getB path
+
+
+makeChanges :
+    (Int -> Maybe a)
+    -> (Int -> Maybe a)
+    -> List ( Int, Int )
+    -> Result BugReport (List (Change a))
+makeChanges getA getB path =
+    case path of
+        [] ->
+            Ok []
+
+        latest :: tail ->
+            makeChangesHelp [] getA getB latest tail
+
+
+makeChangesHelp :
+    List (Change a)
+    -> (Int -> Maybe a)
+    -> (Int -> Maybe a)
+    -> ( Int, Int )
+    -> List ( Int, Int )
+    -> Result BugReport (List (Change a))
+makeChangesHelp changes getA getB ( x, y ) path =
+    case path of
+        [] ->
+            Ok changes
+
+        ( prevX, prevY ) :: tail ->
+            let
+                change =
+                    if x - 1 == prevX && y - 1 == prevY then
+                        case getA x of
+                            Just a ->
+                                Ok (NoChange a)
+
+                            Nothing ->
+                                Err (CannotGetA x)
+
+                    else if x == prevX then
+                        case getB y of
+                            Just b ->
+                                Ok (Added b)
+
+                            Nothing ->
+                                Err (CannotGetB y)
+
+                    else if y == prevY then
+                        case getA x of
+                            Just a ->
+                                Ok (Removed a)
+
+                            Nothing ->
+                                Err (CannotGetA x)
+
+                    else
+                        Err (UnexpectedPath ( x, y ) path)
+            in
+            case change of
+                Err err ->
+                    Err err
+
+                Ok c ->
+                    makeChangesHelp (c :: changes) getA getB ( prevX, prevY ) tail
+
+
+
+-- Wu's O(NP) algorithm (http://myerslab.mpi-cbg.de/wp-content/uploads/2014/06/np_diff.pdf)
+
+
+onp : (Int -> Maybe a) -> (Int -> Maybe a) -> Int -> Int -> List ( Int, Int )
+onp getA getB m n =
+    let
+        v =
+            Array.initialize (m + n + 1) (always [])
+
+        delta =
+            n - m
+    in
+    onpLoopP (snake getA getB) delta m 0 v
+
+
+onpLoopP :
+    (Int -> Int -> List ( Int, Int ) -> ( List ( Int, Int ), Bool ))
+    -> Int
+    -> Int
+    -> Int
+    -> Array (List ( Int, Int ))
+    -> List ( Int, Int )
+onpLoopP snake_ delta offset p v =
+    let
+        ks =
+            if delta > 0 then
+                List.reverse (List.range (delta + 1) (delta + p))
+                    ++ List.range -p delta
+
+            else
+                List.reverse (List.range (delta + 1) p)
+                    ++ List.range (-p + delta) delta
+    in
+    case onpLoopK snake_ offset ks v of
+        Found path ->
+            path
+
+        Continue v_ ->
+            onpLoopP snake_ delta offset (p + 1) v_
+
+
+onpLoopK :
+    (Int -> Int -> List ( Int, Int ) -> ( List ( Int, Int ), Bool ))
+    -> Int
+    -> List Int
+    -> Array (List ( Int, Int ))
+    -> StepResult
+onpLoopK snake_ offset ks v =
+    case ks of
+        [] ->
+            Continue v
+
+        k :: ks_ ->
+            case step snake_ offset k v of
+                Found path ->
+                    Found path
+
+                Continue v_ ->
+                    onpLoopK snake_ offset ks_ v_
+
+
+step :
+    (Int -> Int -> List ( Int, Int ) -> ( List ( Int, Int ), Bool ))
+    -> Int
+    -> Int
+    -> Array (List ( Int, Int ))
+    -> StepResult
+step snake_ offset k v =
+    let
+        fromLeft =
+            Maybe.withDefault [] (Array.get (k - 1 + offset) v)
+
+        fromTop =
+            Maybe.withDefault [] (Array.get (k + 1 + offset) v)
+
+        ( path, ( x, y ) ) =
+            case ( fromLeft, fromTop ) of
+                ( [], [] ) ->
+                    ( [], ( 0, 0 ) )
+
+                ( [], ( topX, topY ) :: _ ) ->
+                    ( fromTop, ( topX + 1, topY ) )
+
+                ( ( leftX, leftY ) :: _, [] ) ->
+                    ( fromLeft, ( leftX, leftY + 1 ) )
+
+                ( ( leftX, leftY ) :: _, ( topX, topY ) :: _ ) ->
+                    -- this implies "remove" comes always earlier than "add"
+                    if leftY + 1 >= topY then
+                        ( fromLeft, ( leftX, leftY + 1 ) )
+
+                    else
+                        ( fromTop, ( topX + 1, topY ) )
+
+        ( newPath, goal ) =
+            snake_ (x + 1) (y + 1) (( x, y ) :: path)
+    in
+    if goal then
+        Found newPath
+
+    else
+        Continue (Array.set (k + offset) newPath v)
+
+
+snake :
+    (Int -> Maybe a)
+    -> (Int -> Maybe a)
+    -> Int
+    -> Int
+    -> List ( Int, Int )
+    -> ( List ( Int, Int ), Bool )
+snake getA getB nextX nextY path =
+    case ( getA nextX, getB nextY ) of
+        ( Just a, Just b ) ->
+            if a == b then
+                snake
+                    getA
+                    getB
+                    (nextX + 1)
+                    (nextY + 1)
+                    (( nextX, nextY ) :: path)
+
+            else
+                ( path, False )
+
+        -- reached bottom-right corner
+        ( Nothing, Nothing ) ->
+            ( path, True )
+
+        _ ->
+            ( path, False )

--- a/src/Vendored/Failure.elm
+++ b/src/Vendored/Failure.elm
@@ -1,0 +1,217 @@
+-- Copied from rtfeldman/node-test-runner : elm/src/Test/Reporter/Console/Format.elm
+-- https://github.com/rtfeldman/node-test-runner/blob/master/elm/src/Test/Reporter/Console/Format.elm
+-- Published under BSD-3-Clause license, see LICENSE_node-test-runner
+
+
+module Vendored.Failure exposing (format)
+
+import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
+import Vendored.Highlightable as Highlightable exposing (Highlightable)
+
+
+format :
+    (List (Highlightable String) -> List (Highlightable String) -> ( String, String ))
+    -> String
+    -> Reason
+    -> String
+format formatEquality description reason =
+    case reason of
+        Custom ->
+            description
+
+        Equality expected actual ->
+            case highlightEqual expected actual of
+                Nothing ->
+                    verticalBar description expected actual
+
+                Just ( highlightedExpected, highlightedActual ) ->
+                    let
+                        ( formattedExpected, formattedActual ) =
+                            formatEquality highlightedExpected highlightedActual
+                    in
+                    verticalBar description formattedExpected formattedActual
+
+        Comparison first second ->
+            verticalBar description first second
+
+        TODO ->
+            description
+
+        Invalid BadDescription ->
+            if description == "" then
+                "The empty string is not a valid test description."
+
+            else
+                "This is an invalid test description: " ++ description
+
+        Invalid _ ->
+            description
+
+        ListDiff expected actual ->
+            listDiffToString 0
+                description
+                { expected = expected
+                , actual = actual
+                }
+                { originalExpected = expected
+                , originalActual = actual
+                }
+
+        CollectionDiff { expected, actual, extra, missing } ->
+            let
+                extraStr =
+                    if List.isEmpty extra then
+                        ""
+
+                    else
+                        "\nThese keys are extra: "
+                            ++ (extra |> String.join ", " |> (\d -> "[ " ++ d ++ " ]"))
+
+                missingStr =
+                    if List.isEmpty missing then
+                        ""
+
+                    else
+                        "\nThese keys are missing: "
+                            ++ (missing |> String.join ", " |> (\d -> "[ " ++ d ++ " ]"))
+            in
+            String.join ""
+                [ verticalBar description expected actual
+                , "\n"
+                , extraStr
+                , missingStr
+                ]
+
+
+highlightEqual : String -> String -> Maybe ( List (Highlightable String), List (Highlightable String) )
+highlightEqual expected actual =
+    if expected == "\"\"" || actual == "\"\"" then
+        -- Diffing when one is the empty string looks silly. Don't bother.
+        Nothing
+
+    else if isFloat expected && isFloat actual then
+        -- Diffing numbers looks silly. Don't bother.
+        Nothing
+
+    else
+        let
+            isHighlighted =
+                Highlightable.resolve
+                    { fromHighlighted = always True
+                    , fromPlain = always False
+                    }
+
+            edgeCount highlightedString =
+                let
+                    highlights =
+                        List.map isHighlighted highlightedString
+                in
+                highlights
+                    |> List.map2 Tuple.pair (List.drop 1 highlights)
+                    |> List.filter (\( lhs, rhs ) -> lhs /= rhs)
+                    |> List.length
+
+            expectedChars =
+                String.toList expected
+
+            actualChars =
+                String.toList actual
+
+            highlightedExpected =
+                Highlightable.diffLists expectedChars actualChars
+                    |> List.map (Highlightable.map String.fromChar)
+
+            highlightedActual =
+                Highlightable.diffLists actualChars expectedChars
+                    |> List.map (Highlightable.map String.fromChar)
+
+            plainCharCount =
+                highlightedExpected
+                    |> List.filter (not << isHighlighted)
+                    |> List.length
+        in
+        if edgeCount highlightedActual > plainCharCount || edgeCount highlightedExpected > plainCharCount then
+            -- Large number of small highlighted blocks. Diff is too messy to be useful.
+            Nothing
+
+        else
+            Just
+                ( highlightedExpected
+                , highlightedActual
+                )
+
+
+isFloat : String -> Bool
+isFloat str =
+    case String.toFloat str of
+        Just _ ->
+            True
+
+        Nothing ->
+            False
+
+
+listDiffToString :
+    Int
+    -> String
+    -> { expected : List String, actual : List String }
+    -> { originalExpected : List String, originalActual : List String }
+    -> String
+listDiffToString index description { expected, actual } originals =
+    case ( expected, actual ) of
+        ( [], [] ) ->
+            [ "Two lists were unequal previously, yet ended up equal later."
+            , "This should never happen!"
+            , "Please report this bug to https://github.com/elm-community/elm-test/issues - and include these lists: "
+            , "\n"
+            , String.join ", " originals.originalExpected
+            , "\n"
+            , String.join ", " originals.originalActual
+            ]
+                |> String.join ""
+
+        ( _ :: _, [] ) ->
+            verticalBar (description ++ " was shorter than")
+                (String.join ", " originals.originalExpected)
+                (String.join ", " originals.originalActual)
+
+        ( [], _ :: _ ) ->
+            verticalBar (description ++ " was longer than")
+                (String.join ", " originals.originalExpected)
+                (String.join ", " originals.originalActual)
+
+        ( firstExpected :: restExpected, firstActual :: restActual ) ->
+            if firstExpected == firstActual then
+                -- They're still the same so far; keep going.
+                listDiffToString (index + 1)
+                    description
+                    { expected = restExpected
+                    , actual = restActual
+                    }
+                    originals
+
+            else
+                -- We found elements that differ; fail!
+                String.join ""
+                    [ verticalBar description
+                        (String.join ", " originals.originalExpected)
+                        (String.join ", " originals.originalActual)
+                    , "\n\nThe first diff is at index "
+                    , String.fromInt index
+                    , ": it was `"
+                    , firstActual
+                    , "`, but `"
+                    , firstExpected
+                    , "` was expected."
+                    ]
+
+
+verticalBar : String -> String -> String -> String
+verticalBar comparison expected actual =
+    [ actual
+    , "╷"
+    , "│ " ++ comparison
+    , "╵"
+    , expected
+    ]
+        |> String.join "\n"

--- a/src/Vendored/FormatMonochrome.elm
+++ b/src/Vendored/FormatMonochrome.elm
@@ -1,0 +1,44 @@
+-- Copied from rtfeldman/node-test-runner : elm/src/Test/Reporter/Console/Format/Monochrome.elm
+-- https://github.com/rtfeldman/node-test-runner/blob/master/elm/src/Test/Reporter/Console/Format/Monochrome.elm
+-- Published under BSD-3-Clause license, see LICENSE_node-test-runner
+
+
+module Vendored.FormatMonochrome exposing (formatEquality)
+
+import Vendored.Highlightable as Highlightable exposing (Highlightable(..))
+
+
+formatEquality : List (Highlightable String) -> List (Highlightable String) -> ( String, String )
+formatEquality highlightedExpected highlightedActual =
+    let
+        ( formattedExpected, expectedIndicators ) =
+            highlightedExpected
+                |> List.map (fromHighlightable "▲")
+                |> List.unzip
+
+        ( formattedActual, actualIndicators ) =
+            highlightedActual
+                |> List.map (fromHighlightable "▼")
+                |> List.unzip
+
+        combinedExpected =
+            String.join "\n"
+                [ String.join "" formattedExpected
+                , String.join "" expectedIndicators
+                ]
+
+        combinedActual =
+            String.join "\n"
+                [ String.join "" actualIndicators
+                , String.join "" formattedActual
+                ]
+    in
+    ( combinedExpected, combinedActual )
+
+
+fromHighlightable : String -> Highlightable String -> ( String, String )
+fromHighlightable indicator =
+    Highlightable.resolve
+        { fromHighlighted = \char -> ( char, indicator )
+        , fromPlain = \char -> ( char, " " )
+        }

--- a/src/Vendored/Highlightable.elm
+++ b/src/Vendored/Highlightable.elm
@@ -1,0 +1,53 @@
+-- Copied from rtfeldman/node-test-runner : elm/src/Test/Reporter/Highlightable.elm
+-- https://github.com/rtfeldman/node-test-runner/blob/master/elm/src/Test/Reporter/Highlightable.elm
+-- Published under BSD-3-Clause license, see LICENSE_node-test-runner
+
+
+module Vendored.Highlightable exposing (Highlightable, diffLists, map, resolve)
+
+import Vendored.Diff as Diff exposing (Change(..))
+
+
+type Highlightable a
+    = Highlighted a
+    | Plain a
+
+
+resolve : { fromHighlighted : a -> b, fromPlain : a -> b } -> Highlightable a -> b
+resolve { fromHighlighted, fromPlain } highlightable =
+    case highlightable of
+        Highlighted val ->
+            fromHighlighted val
+
+        Plain val ->
+            fromPlain val
+
+
+diffLists : List a -> List a -> List (Highlightable a)
+diffLists expected actual =
+    -- TODO make sure this looks reasonable for multiline strings
+    Diff.diff expected actual
+        |> List.concatMap fromDiff
+
+
+map : (a -> b) -> Highlightable a -> Highlightable b
+map transform highlightable =
+    case highlightable of
+        Highlighted val ->
+            Highlighted (transform val)
+
+        Plain val ->
+            Plain (transform val)
+
+
+fromDiff : Change a -> List (Highlightable a)
+fromDiff diff =
+    case diff of
+        Added _ ->
+            []
+
+        Removed char ->
+            [ Highlighted char ]
+
+        NoChange char ->
+            [ Plain char ]

--- a/tests/ProgramTestHttpTests.elm
+++ b/tests/ProgramTestHttpTests.elm
@@ -160,11 +160,13 @@ all =
                             (.body >> Expect.equal """{"ok":900}""")
                         |> expectFailure
                             [ expect ++ "HttpRequest:"
+                            , "         ▼▼▼▼  "
                             , """"{\\"ok\\":true}\""""
-                            , "╵"
-                            , "│ Expect.equal"
                             , "╷"
+                            , "│ Expect.equal"
+                            , "╵"
                             , """"{\\"ok\\":900}\""""
+                            , "         ▲▲▲  "
                             ]
             , testRequest "can assert on request headers" <|
                 \expect assertHttpRequest ->

--- a/tests/ProgramTestTests/SimulatedEffects/PortsTest.elm
+++ b/tests/ProgramTestTests/SimulatedEffects/PortsTest.elm
@@ -38,11 +38,13 @@ all =
                         |> assertOutgoingPortValues "other" (Decode.null ()) (Expect.equal [ () ])
                         |> expectFailure
                             [ assert ++ "OutgoingPortValues: values sent to port \"other\" did not match:"
+                            , "  "
                             , "[]"
-                            , "╵"
-                            , "│ Expect.equal"
                             , "╷"
+                            , "│ Expect.equal"
+                            , "╵"
                             , "[()]"
+                            , " ▲▲ "
                             ]
             , testOutgoingPortValues "clears values after checking" <|
                 \_ assertOutgoingPortValues ->

--- a/tests/Test/Expect.elm
+++ b/tests/Test/Expect.elm
@@ -59,10 +59,11 @@ expectFailureContaining expectedSubstring actualResult =
             Expect.fail "Expected a failure, but got a pass"
 
         Just actualInfo ->
-            Expect.true
-                ("Expected failure message to contain: "
-                    ++ expectedSubstring
-                    ++ "but got\n\n"
-                    ++ actualInfo.description
-                )
-                (String.contains expectedSubstring actualInfo.description)
+            String.contains expectedSubstring actualInfo.description
+                |> Expect.equal True
+                |> Expect.onFail
+                    ("Expected failure message to contain: "
+                        ++ expectedSubstring
+                        ++ "but got\n\n"
+                        ++ actualInfo.description
+                    )


### PR DESCRIPTION
- [x] ran tests locally with `npm test`
<details>
<summary>Screenshot</summary>

![Screenshot 2022-10-12 at 13 32 41](https://user-images.githubusercontent.com/149425/195332275-7982710d-ceb5-43ca-bdad-0d6bfdb65ad4.png)

</details>

- [x] updated CHANGELOG.md if appropriate
(I didn't bump the package version or anything, just made elm-test 2.0.0 work on the main branch)

----

This had to deal with the removal of the deprecated (for 5 years now) function `Test.Runner.Failure.format`. I've opted for the approach `elm-test-runner` chose: vendor an implementation of that function from `node-test-runner`.