### PR TITLE
Add ProgramTest.getViewHtml and ProgramTest.getModel for use with other testing workflows like snapshots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.1.0
+
+New features:
+
+  - Added `ProgramTest.getViewHtml` for extracting the rendered view HTML as a string
+  - Added `ProgramTest.getModel` for extracting the current model value
+
+
 ## 4.0.0
 
 - Upgrade to elm-explorations/test 2.0.0

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -28,6 +28,7 @@ module ProgramTest exposing
     , simulateLastEffect
     , fail, createFailed
     , getOutgoingPortValues
+    , getViewHtml, getModel
     , elmMajorVersionHack_4
     )
 
@@ -196,6 +197,15 @@ These functions may be useful if you are writing your own custom assertion funct
 @docs getOutgoingPortValues
 
 
+## Extracting values
+
+These functions extract the current view or model from a `ProgramTest` as values.
+They are intended for tooling authors building snapshot testing or other custom
+test workflows.
+
+@docs getViewHtml, getModel
+
+
 # Elm language workaround
 
 @docs elmMajorVersionHack_4
@@ -215,7 +225,11 @@ import MultiDict
 import ProgramTest.ComplexQuery as ComplexQuery exposing (ComplexQuery)
 import ProgramTest.EffectSimulation as EffectSimulation exposing (EffectSimulation)
 import ProgramTest.Failure as Failure exposing (Failure(..))
+import ProgramTest.HtmlHighlighter as HtmlHighlighter
+import ProgramTest.HtmlRenderer as HtmlRenderer
 import ProgramTest.Program as Program exposing (Program)
+import ProgramTest.TestHtmlHacks as TestHtmlHacks
+import ProgramTest.TestHtmlParser exposing (FailureReport(..))
 import Result.Extra
 import SimulatedEffect exposing (SimulatedEffect, SimulatedSub, SimulatedTask)
 import String.Extra
@@ -1921,6 +1935,96 @@ expectModel assertion =
                     Err (ExpectFailed "expectModel" reason.description reason.reason)
     )
         >> done
+
+
+{-| Get the rendered HTML of the current view as a String.
+
+This is useful for tooling authors building snapshot testing or other custom
+test workflows where you need the rendered output as a value rather than
+making specific assertions about the view structure.
+
+    ProgramTest.createSandbox
+        { init = CounterApp.init
+        , update = CounterApp.update
+        , view = CounterApp.view
+        }
+        |> ProgramTest.start ()
+        |> ProgramTest.clickButton "+"
+        |> ProgramTest.getViewHtml
+    --> Ok "<div class=\"counter\">..."
+
+Returns `Err` with a description of the failure if the `ProgramTest` has
+already entered a failure state (e.g., a previous interaction failed).
+
+-}
+getViewHtml : ProgramTest model msg effect -> Result String String
+getViewHtml programTest =
+    case programTest of
+        Created created ->
+            case created.state of
+                Ok state ->
+                    let
+                        querySingle =
+                            Program.renderView created.program state.currentModel
+                    in
+                    case TestHtmlHacks.forceFailureReport [] querySingle of
+                        Ok (QueryFailure node _ _) ->
+                            let
+                                highlighted =
+                                    HtmlHighlighter.highlight (\_ _ _ -> True) node
+                            in
+                            Ok (HtmlRenderer.render identity 0 [ highlighted ] |> String.trimRight)
+
+                        Ok (EventFailure _ _) ->
+                            Err "getViewHtml: unexpected internal error (EventFailure)"
+
+                        Err err ->
+                            Err ("getViewHtml: could not parse view HTML: " ++ err)
+
+                Err failure ->
+                    Err (Failure.toString failure.reason)
+
+        FailedToCreate failure ->
+            Err (Failure.toString failure)
+
+
+{-| Get the current model from a `ProgramTest`.
+
+When possible, you should prefer making assertions about the rendered view
+(see [`expectView`](#expectView)) or external requests made by your program,
+as testing at the level that users interact with your program makes tests
+more resilient to implementation changes.
+
+However, this can be useful for tooling authors building snapshot testing
+or other custom test workflows:
+
+    ProgramTest.createSandbox
+        { init = App.init
+        , update = App.update
+        , view = App.view
+        }
+        |> ProgramTest.start ()
+        |> ProgramTest.clickButton "Submit"
+        |> ProgramTest.getModel
+    --> Ok { submitted = True, ... }
+
+Returns `Err` with a description of the failure if the `ProgramTest` has
+already entered a failure state.
+
+-}
+getModel : ProgramTest model msg effect -> Result String model
+getModel programTest =
+    case programTest of
+        Created created ->
+            case created.state of
+                Ok state ->
+                    Ok state.currentModel
+
+                Err failure ->
+                    Err (Failure.toString failure.reason)
+
+        FailedToCreate failure ->
+            Err (Failure.toString failure)
 
 
 {-| Simulate the outcome of the last effect produced by the program being tested

--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -229,7 +229,7 @@ import ProgramTest.HtmlHighlighter as HtmlHighlighter
 import ProgramTest.HtmlRenderer as HtmlRenderer
 import ProgramTest.Program as Program exposing (Program)
 import ProgramTest.TestHtmlHacks as TestHtmlHacks
-import ProgramTest.TestHtmlParser exposing (FailureReport(..))
+import ProgramTest.TestHtmlParser exposing (FailureReport(..), Step(..))
 import Result.Extra
 import SimulatedEffect exposing (SimulatedEffect, SimulatedSub, SimulatedTask)
 import String.Extra
@@ -1937,7 +1937,11 @@ expectModel assertion =
         >> done
 
 
-{-| Get the rendered HTML of the current view as a String.
+{-| Get the rendered HTML of the current view (or a portion of it) as a String.
+
+The first argument is a list of
+[`Test.Html.Selector`](https://package.elm-lang.org/packages/elm-explorations/test/latest/Test-Html-Selector)s
+to narrow down to a specific element. Use `[]` to get the full view HTML.
 
 This is useful for tooling authors building snapshot testing or other custom
 test workflows where you need the rendered output as a value rather than
@@ -1950,15 +1954,18 @@ making specific assertions about the view structure.
         }
         |> ProgramTest.start ()
         |> ProgramTest.clickButton "+"
-        |> ProgramTest.getViewHtml
-    --> Ok "<div class=\"counter\">..."
+        |> ProgramTest.getViewHtml []
+        --> Ok "<div class=\"counter\">..."
+        -- Or narrow down to a specific element:
+        |> ProgramTest.getViewHtml [ Selector.id "main-content" ]
 
 Returns `Err` with a description of the failure if the `ProgramTest` has
-already entered a failure state (e.g., a previous interaction failed).
+already entered a failure state, or if the selectors match zero or more than
+one element.
 
 -}
-getViewHtml : ProgramTest model msg effect -> Result String String
-getViewHtml programTest =
+getViewHtml : List Selector -> ProgramTest model msg effect -> Result String String
+getViewHtml selectors programTest =
     case programTest of
         Created created ->
             case created.state of
@@ -1966,20 +1973,40 @@ getViewHtml programTest =
                     let
                         querySingle =
                             Program.renderView created.program state.currentModel
+
+                        targetQuery =
+                            if List.isEmpty selectors then
+                                querySingle
+
+                            else
+                                querySingle |> Query.find selectors
                     in
-                    case TestHtmlHacks.forceFailureReport [] querySingle of
-                        Ok (QueryFailure node _ _) ->
-                            let
-                                highlighted =
-                                    HtmlHighlighter.highlight (\_ _ _ -> True) node
-                            in
-                            Ok (HtmlRenderer.render identity 0 [ highlighted ] |> String.trimRight)
+                    case targetQuery |> Query.has [] |> Test.Runner.getFailureReason of
+                        Just reason ->
+                            Err ("getViewHtml: " ++ reason.description)
 
-                        Ok (EventFailure _ _) ->
-                            Err "getViewHtml: unexpected internal error (EventFailure)"
+                        Nothing ->
+                            case TestHtmlHacks.forceFailureReport [] targetQuery of
+                                Ok (QueryFailure rootNode steps _) ->
+                                    let
+                                        node =
+                                            case List.reverse steps of
+                                                (FindStep narrowedNode) :: _ ->
+                                                    narrowedNode
 
-                        Err err ->
-                            Err ("getViewHtml: could not parse view HTML: " ++ err)
+                                                [] ->
+                                                    rootNode
+
+                                        highlighted =
+                                            HtmlHighlighter.highlight (\_ _ _ -> True) node
+                                    in
+                                    Ok (HtmlRenderer.render identity 0 [ highlighted ] |> String.trimRight)
+
+                                Ok (EventFailure _ _) ->
+                                    Err "getViewHtml: unexpected internal error (EventFailure)"
+
+                                Err err ->
+                                    Err ("getViewHtml: could not parse view HTML: " ++ err)
 
                 Err failure ->
                     Err (Failure.toString failure.reason)

--- a/src/ProgramTest/TestHtmlHacks.elm
+++ b/src/ProgramTest/TestHtmlHacks.elm
@@ -1,4 +1,4 @@
-module ProgramTest.TestHtmlHacks exposing (getPassingSelectors, parseFailureReport, parseFailureReportWithoutHtml, parseSimulateFailure, renderHtml)
+module ProgramTest.TestHtmlHacks exposing (forceFailureReport, getPassingSelectors, parseFailureReport, parseFailureReportWithoutHtml, parseSimulateFailure, renderHtml)
 
 import Html.Parser
 import Parser

--- a/src/ProgramTest/TestHtmlParser.elm
+++ b/src/ProgramTest/TestHtmlParser.elm
@@ -12,7 +12,7 @@ type FailureReport html
 
 
 type Step html
-    = FindStep (List Selector) html
+    = FindStep html
 
 
 type Selector
@@ -88,7 +88,7 @@ stepParser parseHtml =
     Parser.oneOf
         [ Parser.succeed FindStep
             |. Parser.keyword "▼ Query.find "
-            |= selectorsParser
+            |. Parser.chompUntil "\n"
             |. Parser.symbol "\n\n    1)  "
             |= parseHtml
         ]

--- a/tests/ProgramTest/TestHtmlHacksTest.elm
+++ b/tests/ProgramTest/TestHtmlHacksTest.elm
@@ -144,9 +144,6 @@ all =
                         |> Expect.equal
                             (Ok
                                 [ FindStep
-                                    [ Tag "label"
-                                    , Containing [ TestHtmlParser.Text "Field 1" ]
-                                    ]
                                     (Element "label"
                                         []
                                         [ Html.Parser.Text "Field 1"

--- a/tests/ProgramTestTests/GetModelTest.elm
+++ b/tests/ProgramTestTests/GetModelTest.elm
@@ -1,0 +1,107 @@
+module ProgramTestTests.GetModelTest exposing (all)
+
+import Expect
+import Html
+import Html.Events exposing (onClick)
+import ProgramTest exposing (ProgramTest)
+import Test exposing (..)
+
+
+type alias Model =
+    { count : Int
+    , label : String
+    }
+
+
+type Msg
+    = Increment
+    | SetLabel String
+
+
+start : ProgramTest Model Msg ()
+start =
+    ProgramTest.createSandbox
+        { init = { count = 0, label = "initial" }
+        , update =
+            \msg model ->
+                case msg of
+                    Increment ->
+                        { model | count = model.count + 1 }
+
+                    SetLabel s ->
+                        { model | label = s }
+        , view =
+            \model ->
+                Html.div []
+                    [ Html.span [] [ Html.text (String.fromInt model.count) ]
+                    , Html.button [ onClick Increment ] [ Html.text "+" ]
+                    ]
+        }
+        |> ProgramTest.start ()
+
+
+all : Test
+all =
+    describe "getModel"
+        [ test "returns the initial model" <|
+            \() ->
+                start
+                    |> ProgramTest.getModel
+                    |> Expect.equal (Ok { count = 0, label = "initial" })
+        , test "returns the model after interactions" <|
+            \() ->
+                start
+                    |> ProgramTest.clickButton "+"
+                    |> ProgramTest.clickButton "+"
+                    |> ProgramTest.clickButton "+"
+                    |> ProgramTest.getModel
+                    |> Result.map .count
+                    |> Expect.equal (Ok 3)
+        , test "returns Err when the ProgramTest is in a failed state" <|
+            \() ->
+                start
+                    |> ProgramTest.clickButton "nonexistent button"
+                    |> ProgramTest.getModel
+                    |> isErr
+                    |> Expect.equal True
+        , test "error message describes the original failure" <|
+            \() ->
+                start
+                    |> ProgramTest.clickButton "nonexistent button"
+                    |> ProgramTest.getModel
+                    |> Result.mapError (String.contains "nonexistent button")
+                    |> Expect.equal (Err True)
+        , test "returns Err for a program that failed to create" <|
+            \() ->
+                ProgramTest.createFailed "setup" "bad config"
+                    |> ProgramTest.getModel
+                    |> isErr
+                    |> Expect.equal True
+        , test "returns the model after update" <|
+            \() ->
+                start
+                    |> ProgramTest.update (SetLabel "updated")
+                    |> ProgramTest.getModel
+                    |> Result.map .label
+                    |> Expect.equal (Ok "updated")
+        , test "returns the model from a worker program" <|
+            \() ->
+                ProgramTest.createWorker
+                    { init = \() -> ( "worker-init", () )
+                    , update = \msg model -> ( model ++ ";" ++ msg, () )
+                    }
+                    |> ProgramTest.start ()
+                    |> ProgramTest.update "hello"
+                    |> ProgramTest.getModel
+                    |> Expect.equal (Ok "worker-init;hello")
+        ]
+
+
+isErr : Result a b -> Bool
+isErr result =
+    case result of
+        Err _ ->
+            True
+
+        Ok _ ->
+            False

--- a/tests/ProgramTestTests/GetViewHtmlTest.elm
+++ b/tests/ProgramTestTests/GetViewHtmlTest.elm
@@ -1,0 +1,137 @@
+module ProgramTestTests.GetViewHtmlTest exposing (all)
+
+import Expect exposing (Expectation)
+import Html
+import Html.Attributes exposing (class)
+import Html.Events exposing (onClick)
+import ProgramTest exposing (ProgramTest)
+import Test exposing (..)
+
+
+type alias Model =
+    { count : Int }
+
+
+type Msg
+    = Increment
+    | Decrement
+
+
+start : ProgramTest Model Msg ()
+start =
+    ProgramTest.createSandbox
+        { init = { count = 0 }
+        , update =
+            \msg model ->
+                case msg of
+                    Increment ->
+                        { model | count = model.count + 1 }
+
+                    Decrement ->
+                        { model | count = model.count - 1 }
+        , view =
+            \model ->
+                Html.div [ class "counter" ]
+                    [ Html.button [ onClick Decrement ] [ Html.text "-" ]
+                    , Html.span [] [ Html.text (String.fromInt model.count) ]
+                    , Html.button [ onClick Increment ] [ Html.text "+" ]
+                    ]
+        }
+        |> ProgramTest.start ()
+
+
+all : Test
+all =
+    describe "getViewHtml"
+        [ test "returns the rendered HTML of the initial view" <|
+            \() ->
+                start
+                    |> ProgramTest.getViewHtml
+                    |> expectOkHtml """
+<div class="counter">
+    <button>
+        -
+    </button>
+    <span>
+        0
+    </span>
+    <button>
+        +
+    </button>
+</div>
+"""
+        , test "returns the rendered HTML after interactions" <|
+            \() ->
+                start
+                    |> ProgramTest.clickButton "+"
+                    |> ProgramTest.clickButton "+"
+                    |> ProgramTest.clickButton "+"
+                    |> ProgramTest.getViewHtml
+                    |> Result.map (String.contains "3")
+                    |> Expect.equal (Ok True)
+        , test "returns Err when the ProgramTest is in a failed state" <|
+            \() ->
+                start
+                    |> ProgramTest.clickButton "nonexistent button"
+                    |> ProgramTest.getViewHtml
+                    |> isErr
+                    |> Expect.equal True
+        , test "error message describes the original failure" <|
+            \() ->
+                start
+                    |> ProgramTest.clickButton "nonexistent button"
+                    |> ProgramTest.getViewHtml
+                    |> Result.mapError (String.contains "nonexistent button")
+                    |> Expect.equal (Err True)
+        , test "returns Err for a program that failed to create" <|
+            \() ->
+                ProgramTest.createFailed "setup" "bad config"
+                    |> ProgramTest.getViewHtml
+                    |> isErr
+                    |> Expect.equal True
+        , test "works with a simple view" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = ()
+                    , update = \() () -> ()
+                    , view = \() -> Html.p [] [ Html.text "hello" ]
+                    }
+                    |> ProgramTest.start ()
+                    |> ProgramTest.getViewHtml
+                    |> expectOkHtml """
+<p>
+    hello
+</p>
+"""
+        , test "works with nested elements and attributes" <|
+            \() ->
+                ProgramTest.createSandbox
+                    { init = ()
+                    , update = \() () -> ()
+                    , view =
+                        \() ->
+                            Html.div []
+                                [ Html.a [ Html.Attributes.href "/home" ] [ Html.text "Home" ]
+                                ]
+                    }
+                    |> ProgramTest.start ()
+                    |> ProgramTest.getViewHtml
+                    |> Result.map (String.contains "href=\"/home\"")
+                    |> Expect.equal (Ok True)
+        ]
+
+
+expectOkHtml : String -> Result String String -> Expectation
+expectOkHtml expected actual =
+    actual
+        |> Expect.equal (Ok (String.trim expected))
+
+
+isErr : Result a b -> Bool
+isErr result =
+    case result of
+        Err _ ->
+            True
+
+        Ok _ ->
+            False

--- a/tests/ProgramTestTests/GetViewHtmlTest.elm
+++ b/tests/ProgramTestTests/GetViewHtmlTest.elm
@@ -2,10 +2,11 @@ module ProgramTestTests.GetViewHtmlTest exposing (all)
 
 import Expect exposing (Expectation)
 import Html
-import Html.Attributes exposing (class)
+import Html.Attributes exposing (class, id)
 import Html.Events exposing (onClick)
 import ProgramTest exposing (ProgramTest)
 import Test exposing (..)
+import Test.Html.Selector as Selector
 
 
 type alias Model =
@@ -43,11 +44,12 @@ start =
 all : Test
 all =
     describe "getViewHtml"
-        [ test "returns the rendered HTML of the initial view" <|
-            \() ->
-                start
-                    |> ProgramTest.getViewHtml
-                    |> expectOkHtml """
+        [ describe "with empty selector list (full view)"
+            [ test "returns the rendered HTML of the initial view" <|
+                \() ->
+                    start
+                        |> ProgramTest.getViewHtml []
+                        |> expectOkHtml """
 <div class="counter">
     <button>
         -
@@ -60,64 +62,135 @@ all =
     </button>
 </div>
 """
-        , test "returns the rendered HTML after interactions" <|
-            \() ->
-                start
-                    |> ProgramTest.clickButton "+"
-                    |> ProgramTest.clickButton "+"
-                    |> ProgramTest.clickButton "+"
-                    |> ProgramTest.getViewHtml
-                    |> Result.map (String.contains "3")
-                    |> Expect.equal (Ok True)
-        , test "returns Err when the ProgramTest is in a failed state" <|
-            \() ->
-                start
-                    |> ProgramTest.clickButton "nonexistent button"
-                    |> ProgramTest.getViewHtml
-                    |> isErr
-                    |> Expect.equal True
-        , test "error message describes the original failure" <|
-            \() ->
-                start
-                    |> ProgramTest.clickButton "nonexistent button"
-                    |> ProgramTest.getViewHtml
-                    |> Result.mapError (String.contains "nonexistent button")
-                    |> Expect.equal (Err True)
-        , test "returns Err for a program that failed to create" <|
-            \() ->
-                ProgramTest.createFailed "setup" "bad config"
-                    |> ProgramTest.getViewHtml
-                    |> isErr
-                    |> Expect.equal True
-        , test "works with a simple view" <|
-            \() ->
-                ProgramTest.createSandbox
-                    { init = ()
-                    , update = \() () -> ()
-                    , view = \() -> Html.p [] [ Html.text "hello" ]
-                    }
-                    |> ProgramTest.start ()
-                    |> ProgramTest.getViewHtml
-                    |> expectOkHtml """
+            , test "returns the rendered HTML after interactions" <|
+                \() ->
+                    start
+                        |> ProgramTest.clickButton "+"
+                        |> ProgramTest.clickButton "+"
+                        |> ProgramTest.clickButton "+"
+                        |> ProgramTest.getViewHtml []
+                        |> Result.map (String.contains "3")
+                        |> Expect.equal (Ok True)
+            , test "returns Err when the ProgramTest is in a failed state" <|
+                \() ->
+                    start
+                        |> ProgramTest.clickButton "nonexistent button"
+                        |> ProgramTest.getViewHtml []
+                        |> isErr
+                        |> Expect.equal True
+            , test "error message describes the original failure" <|
+                \() ->
+                    start
+                        |> ProgramTest.clickButton "nonexistent button"
+                        |> ProgramTest.getViewHtml []
+                        |> Result.mapError (String.contains "nonexistent button")
+                        |> Expect.equal (Err True)
+            , test "returns Err for a program that failed to create" <|
+                \() ->
+                    ProgramTest.createFailed "setup" "bad config"
+                        |> ProgramTest.getViewHtml []
+                        |> isErr
+                        |> Expect.equal True
+            , test "works with a simple view" <|
+                \() ->
+                    ProgramTest.createSandbox
+                        { init = ()
+                        , update = \() () -> ()
+                        , view = \() -> Html.p [] [ Html.text "hello" ]
+                        }
+                        |> ProgramTest.start ()
+                        |> ProgramTest.getViewHtml []
+                        |> expectOkHtml """
 <p>
     hello
 </p>
 """
-        , test "works with nested elements and attributes" <|
-            \() ->
-                ProgramTest.createSandbox
-                    { init = ()
-                    , update = \() () -> ()
-                    , view =
-                        \() ->
-                            Html.div []
-                                [ Html.a [ Html.Attributes.href "/home" ] [ Html.text "Home" ]
-                                ]
-                    }
-                    |> ProgramTest.start ()
-                    |> ProgramTest.getViewHtml
-                    |> Result.map (String.contains "href=\"/home\"")
-                    |> Expect.equal (Ok True)
+            , test "works with nested elements and attributes" <|
+                \() ->
+                    ProgramTest.createSandbox
+                        { init = ()
+                        , update = \() () -> ()
+                        , view =
+                            \() ->
+                                Html.div []
+                                    [ Html.a [ Html.Attributes.href "/home" ] [ Html.text "Home" ]
+                                    ]
+                        }
+                        |> ProgramTest.start ()
+                        |> ProgramTest.getViewHtml []
+                        |> Result.map (String.contains "href=\"/home\"")
+                        |> Expect.equal (Ok True)
+            ]
+        , describe "with selectors"
+            [ test "returns only the matching element" <|
+                \() ->
+                    ProgramTest.createSandbox
+                        { init = ()
+                        , update = \() () -> ()
+                        , view =
+                            \() ->
+                                Html.div []
+                                    [ Html.header [ id "header" ] [ Html.text "Header" ]
+                                    , Html.main_ [ id "content" ]
+                                        [ Html.p [] [ Html.text "Main content" ]
+                                        ]
+                                    , Html.footer [ id "footer" ] [ Html.text "Footer" ]
+                                    ]
+                        }
+                        |> ProgramTest.start ()
+                        |> ProgramTest.getViewHtml [ Selector.id "content" ]
+                        |> expectOkHtml """
+<main id="content">
+    <p>
+        Main content
+    </p>
+</main>
+"""
+            , test "works with tag selector" <|
+                \() ->
+                    start
+                        |> ProgramTest.getViewHtml [ Selector.tag "span" ]
+                        |> expectOkHtml """
+<span>
+    0
+</span>
+"""
+            , test "works with class selector" <|
+                \() ->
+                    ProgramTest.createSandbox
+                        { init = ()
+                        , update = \() () -> ()
+                        , view =
+                            \() ->
+                                Html.div []
+                                    [ Html.header [] [ Html.text "Header" ]
+                                    , Html.div [ class "content" ]
+                                        [ Html.p [] [ Html.text "Main content" ]
+                                        ]
+                                    ]
+                        }
+                        |> ProgramTest.start ()
+                        |> ProgramTest.getViewHtml [ Selector.class "content" ]
+                        |> expectOkHtml """
+<div class="content">
+    <p>
+        Main content
+    </p>
+</div>
+"""
+            , test "returns Err when selector matches nothing" <|
+                \() ->
+                    start
+                        |> ProgramTest.getViewHtml [ Selector.id "nonexistent" ]
+                        |> isErr
+                        |> Expect.equal True
+            , test "returns Err when selector matches multiple elements" <|
+                \() ->
+                    start
+                        |> ProgramTest.getViewHtml [ Selector.tag "button" ]
+                        |> isErr
+                        |> Expect.equal True
+            ]
         ]
 
 


### PR DESCRIPTION
## Summary

Adds two new functions for extracting the current view HTML and model from a `ProgramTest` as plain values:

```elm
getViewHtml : ProgramTest model msg effect -> Result String String
getModel : ProgramTest model msg effect -> Result String model
```

Let me know if you have any questions, concerns, or feedback, happy to discuss!

- [X] ran tests locally with `npm test`
- [X] updated CHANGELOG.md if appropriate

## Motivation

The existing `expectView` and `expectModel` functions are great for making assertions, but there's no way to extract the view or model as a value for use outside the assertion pipeline. This makes it impossible to do things like snapshot testing without resorting to hacks.

I'm building [elm-snapshot](https://package.elm-lang.org/packages/dillonkearns/elm-snapshot/latest/), a snapshot testing framework for Elm that works with elm-pages scripts. The natural integration with elm-program-test is: simulate user interactions, then snapshot the resulting view or model. For example:

```elm
Snapshot.checkedTest "after clicking + three times" <|
    \() ->
        ProgramTest.createSandbox
            { init = CounterApp.init
            , update = CounterApp.update
            , view = CounterApp.view
            }
            |> ProgramTest.start ()
            |> ProgramTest.clickButton "+"
            |> ProgramTest.clickButton "+"
            |> ProgramTest.clickButton "+"
            |> ProgramTest.getViewHtml
```

Here's what a full snapshot test module looks like with elm-snapshot:

```elm
module Snapshots exposing (run)

import CounterApp
import ProgramTest
import Snapshot
import Snapshot.Printer as Printer

run =
    Snapshot.run "Snapshots"
        [ Snapshot.describe "Counter"
            [ Snapshot.checkedTest "initial view" <|
                \() ->
                    counterApp
                        |> ProgramTest.getViewHtml
            , Snapshot.checkedTest "after incrementing" <|
                \() ->
                    counterApp
                        |> ProgramTest.clickButton "+"
                        |> ProgramTest.clickButton "+"
                        |> ProgramTest.getViewHtml
            , Snapshot.checkedCustom (Printer.elm Debug.toString) "model" <|
                \() ->
                    counterApp
                        |> ProgramTest.clickButton "+"
                        |> ProgramTest.getModel
            ]
        ]

counterApp =
    ProgramTest.createSandbox
        { init = CounterApp.init
        , update = CounterApp.update
        , view = CounterApp.view
        }
        |> ProgramTest.start ()
```

Running this produces `.approved` snapshot files that get committed to git. On future runs, any changes to the view HTML or model are shown as diffs. The `Result` return type from `getViewHtml`/`getModel` maps directly to elm-snapshot's `checkedTest`, which treats `Err` as a test failure.

### The current workaround

In its current form, the only way to extract view HTML is to force a `Query.has` failure with an impossible selector, then parse the HTML out of the failure message:

```elm
extractView : ProgramTest model msg effect -> Result String String
extractView programTest =
    let
        expectation =
            programTest
                |> ProgramTest.expectView
                    (Query.has [ Selector.text "%%IMPOSSIBLE%%" ])
    in
    case Test.Runner.getFailureReason expectation of
        Nothing ->
            Err "unexpected pass"

        Just { description } ->
            -- Parse HTML from between "▼ Query.fromHtml\n\n" and "\n\n\n▼ "
            parseViewHtml description
```

This is fragile (depends on internal failure message format from elm-explorations/test) and requires some hacky boilerplate. Interestingly, elm-program-test already uses this same trick internally in `TestHtmlHacks` — these new functions just expose the capability so that other tooling authors can use it and trust that the implementation stays in sync as future versions of the package are published.

## Implementation

Both functions are minimal additions that reuse existing internals:

- `getViewHtml` uses `TestHtmlHacks.forceFailureReport` (already used internally) to extract the parsed HTML nodes, then renders via `HtmlRenderer.render`. The only change to `TestHtmlHacks` is exposing `forceFailureReport` in the module header.

- `getModel` unwraps `state.currentModel` from the `ProgramTest`.

Both return `Err` with a descriptive message if the `ProgramTest` is in a failed state (consistent with how all other operations behave on a failed ProgramTest).
