### PR TITLE
Change wording for a tag onClick advice

### DIFF
--- a/src/ProgramTest.elm
+++ b/src/ProgramTest.elm
@@ -1099,7 +1099,7 @@ clickLink linkText href =
                     Err
                         (CustomFailure functionDescription
                             (String.concat
-                                [ "Found an `<a href=\"...\">` tag has an onClick handler, "
+                                [ "Found an `<a href=\"...\">` tag with an onClick handler, "
                                 , "but the handler is overriding ctrl-click and meta-click.\n\n"
                                 , "A properly behaved single-page app should not override ctrl- and meta-clicks on `<a>` tags "
                                 , "because this prevents users from opening links in new tabs/windows.\n\n"

--- a/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
+++ b/tests/ProgramTestTests/UserInput/ClickLinkTest.elm
@@ -116,7 +116,7 @@ all =
                     |> ProgramTest.clickLink "SPA" "#search"
                     |> ProgramTest.done
                     |> expectFailure
-                        [ """clickLink "SPA": Found an `<a href="...">` tag has an onClick handler, but the handler is overriding ctrl-click and meta-click."""
+                        [ """clickLink "SPA": Found an `<a href="...">` tag with an onClick handler, but the handler is overriding ctrl-click and meta-click."""
                         , ""
                         , "A properly behaved single-page app should not override ctrl- and meta-clicks on `<a>` tags because this prevents users from opening links in new tabs/windows."
                         , ""


### PR DESCRIPTION
- [x] ran tests locally with `npm test`
- [x] updated CHANGELOG.md if appropriate

I don't know if this is the best wording, but it's at least better than previously which I believe was incorrect.